### PR TITLE
配列クラスを整備する

### DIFF
--- a/sakura_core/_main/CCommandLine.cpp
+++ b/sakura_core/_main/CCommandLine.cpp
@@ -329,7 +329,7 @@ void CCommandLine::ParseCommandLine( LPCWSTR pszCmdLineSrc, bool bResponse )
 		nPos = 0;
 	}
 
-	CNativeW cmResponseFile = L"";
+	CNativeW cmResponseFile{ L"" };
 	LPWSTR pszCmdLineWork = new WCHAR[lstrlen( pszCmdLineSrc ) + 1];
 	wcscpy( pszCmdLineWork, pszCmdLineSrc );
 	int nCmdLineWorkLen = lstrlen( pszCmdLineWork );

--- a/sakura_core/_main/CControlTray.cpp
+++ b/sakura_core/_main/CControlTray.cpp
@@ -155,20 +155,20 @@ void CControlTray::DoGrep()
 		return;
 	}
 
-	if( 0 < m_pShareData->m_sSearchKeywords.m_aSearchKeys.size()
-		&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence ){
+	if (!m_pShareData->m_sSearchKeywords.m_aSearchKeys.empty()
+		&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence) {
 		m_cDlgGrep.m_strText = m_pShareData->m_sSearchKeywords.m_aSearchKeys[0];
 	}
-	if( 0 < m_pShareData->m_sSearchKeywords.m_aGrepFiles.size() ){
+	if (!m_pShareData->m_sSearchKeywords.m_aGrepFiles.empty()) {
 		m_cDlgGrep.m_szFile = m_pShareData->m_sSearchKeywords.m_aGrepFiles[0];		/* 検索ファイル */
 	}
-	if( 0 < m_pShareData->m_sSearchKeywords.m_aGrepFolders.size() ){
+	if (!m_pShareData->m_sSearchKeywords.m_aGrepFolders.empty()) {
 		m_cDlgGrep.m_szFolder = m_pShareData->m_sSearchKeywords.m_aGrepFolders[0];	/* 検索フォルダー */
 	}
-	if (0 < m_pShareData->m_sSearchKeywords.m_aExcludeFiles.size()) {
+	if (!m_pShareData->m_sSearchKeywords.m_aExcludeFiles.empty()) {
 		m_cDlgGrep.m_szExcludeFile = m_pShareData->m_sSearchKeywords.m_aExcludeFiles[0];	/* 除外ファイル */
 	}
-	if (0 < m_pShareData->m_sSearchKeywords.m_aExcludeFolders.size()) {
+	if (!m_pShareData->m_sSearchKeywords.m_aExcludeFolders.empty()) {
 		m_cDlgGrep.m_szExcludeFolder = m_pShareData->m_sSearchKeywords.m_aExcludeFolders[0];	/* 除外フォルダー */
 	}
 

--- a/sakura_core/_os/CClipboard.cpp
+++ b/sakura_core/_os/CClipboard.cpp
@@ -230,11 +230,13 @@ bool CClipboard::SetText(
 	return true;
 }
 
-bool CClipboard::SetHtmlText(const CNativeW& cmemBUf)
+bool CClipboard::SetHtmlText(std::wstring_view text) const
 {
 	if( !m_bOpenResult ){
 		return false;
 	}
+
+	const CNativeW cmemBUf{ text };
 
 	CNativeA cmemUtf8;
 	CUtf8().UnicodeToCode(cmemBUf, cmemUtf8._GetMemory());

--- a/sakura_core/_os/CClipboard.h
+++ b/sakura_core/_os/CClipboard.h
@@ -69,7 +69,7 @@ public:
 
 	void Empty() const; //!< クリップボードを空にする
 	bool SetText(const wchar_t* pData, size_t nDataLen, bool bColumnSelect, bool bLineSelect, UINT uFormat = (UINT)-1);   //!< テキストを設定する
-	bool SetHtmlText(const CNativeW& cmemBUf);
+	bool	SetHtmlText(std::wstring_view text) const;
 	bool GetText(IWBuffer* cmemBuf, bool* pbColumnSelect, bool* pbLineSelect, const CEol& cEol, UINT uGetFormat = (UINT)-1); //!< テキストを取得する
 	bool GetText(CNativeW* cmemBuf, bool* pbColumnSelect, bool* pbLineSelect, const CEol& cEol, UINT uGetFormat = (UINT)-1); //!< テキストを取得する
 	bool GetText(std::wstring* cmemBuf, bool* pbColumnSelect, bool* pbLineSelect, const CEol& cEol, UINT uGetFormat = (UINT)-1); //!< テキストを取得する

--- a/sakura_core/charset/charcode.cpp
+++ b/sakura_core/charset/charcode.cpp
@@ -25,6 +25,23 @@ const std::array<unsigned char, 128> gm_keyword_char = {
 	/* 0: not-keyword, 1:__iscsym(), 2:user-define */
 };
 
+namespace cxx {
+
+std::wstring_view GetFaceName(const HFONT hFont)
+{
+	std::wstring_view faceName{};
+
+	if (LOGFONT lf{};
+		hFont && ::GetObjectW(hFont, sizeof(LOGFONT), &lf))
+	{
+		faceName = lf.lfFaceName;
+	}
+
+	return faceName;
+}
+
+} // namespace cxx
+
 namespace WCODE
 {
 	static bool s_MultiFont;
@@ -135,8 +152,8 @@ void CCharWidthCache::Clear()
 	if (!m_pCache) return;
 
 	// キャッシュのクリア
-	m_pCache->m_lfFaceName1 = m_hFont1 && ::GetObjectW(m_hFont1, sizeof(LOGFONT), &lf) ? lf.lfFaceName : L"";
-	m_pCache->m_lfFaceName2 = m_hFont2 && ::GetObjectW(m_hFont2, sizeof(LOGFONT), &lf) ? lf.lfFaceName : L"";
+	m_pCache->m_lfFaceName1 = cxx::GetFaceName(m_hFont1);
+	m_pCache->m_lfFaceName2 = cxx::GetFaceName(m_hFont2);
 	m_pCache->m_nCharPxWidthCache.fill(0);
 	m_pCache->m_nCharWidthCacheTest = 0x12345678;
 }

--- a/sakura_core/cmd/CViewCommander_Grep.cpp
+++ b/sakura_core/cmd/CViewCommander_Grep.cpp
@@ -143,7 +143,7 @@ void CViewCommander::Command_GREP_REPLACE_DLG( void )
 		cDlgGrepRep.m_strText = cmemCurText.GetStringPtr();
 		cDlgGrepRep.m_bSetText = true;
 	}
-	if( 0 < GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.size() ){
+	if (!GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.empty()) {
 		if( cDlgGrepRep.m_nReplaceKeySequence < GetDllShareData().m_Common.m_sSearch.m_nReplaceKeySequence ){
 			cDlgGrepRep.m_strText2 = GetDllShareData().m_sSearchKeywords.m_aReplaceKeys[0];
 		}

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -97,7 +97,7 @@ void CViewCommander::Command_SAVEKEYMACRO( void )
 	if( _IS_REL_PATH( GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER ) ){
 		GetInidirOrExedir( szInitDir, GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER );
 	}else{
-		szInitDir = GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER.c_str();	/* マクロ用フォルダー */
+		szInitDir = GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER;	/* マクロ用フォルダー */
 	}
 	/* ファイルオープンダイアログの初期化 */
 	cDlgOpenFile.Create(

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -142,7 +142,7 @@ void CViewCommander::Command_LOADKEYMACRO() const
 	if( _IS_REL_PATH( pszFolder ) ){
 		GetInidirOrExedir( szInitDir, pszFolder );
 	}else{
-		szInitDir = pszFolder;	/* マクロ用フォルダー */
+		szInitDir = std::wstring_view(pszFolder);
 	}
 	/* ファイルオープンダイアログの初期化 */
 	cDlgOpenFile.Create(

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -134,16 +134,19 @@ void CViewCommander::Command_LOADKEYMACRO() const
 	auto& cDlgOpenFile = *CDlgOpenFile::getInstance();
 	SFilePath szPath;
 	SFilePath szInitDir;
-	const WCHAR*		pszFolder;
 	szPath[0] = L'\0';
-	pszFolder = GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER;
+
 	// 2003.06.23 Moca 相対パスは実行ファイルからのパス
 	// 2007.05.19 ryoji 相対パスは設定ファイルからのパスを優先
-	if( _IS_REL_PATH( pszFolder ) ){
+	if (const auto& pszFolder = GetDllShareData().m_Common.m_sMacro.m_szMACROFOLDER;
+		_IS_REL_PATH(pszFolder))
+	{
 		GetInidirOrExedir( szInitDir, pszFolder );
-	}else{
-		szInitDir = std::wstring_view(pszFolder);
 	}
+	else {
+		szInitDir = pszFolder;
+	}
+
 	/* ファイルオープンダイアログの初期化 */
 	cDlgOpenFile.Create(
 		G_AppInstance(),

--- a/sakura_core/cmd/CViewCommander_Search.cpp
+++ b/sakura_core/cmd/CViewCommander_Search.cpp
@@ -496,7 +496,7 @@ void CViewCommander::Command_REPLACE_DIALOG( void )
 	if( 0 < cmemCurText.GetStringLength() ){
 		GetEditWindow()->m_cDlgReplace.m_strText = cmemCurText.GetStringPtr();
 	}
-	if( 0 < GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.size() ){
+	if (!GetDllShareData().m_sSearchKeywords.m_aReplaceKeys.empty()) {
 		if( GetEditWindow()->m_cDlgReplace.m_nReplaceKeySequence < GetDllShareData().m_Common.m_sSearch.m_nReplaceKeySequence ){
 			GetEditWindow()->m_cDlgReplace.m_strText2 = GetDllShareData().m_sSearchKeywords.m_aReplaceKeys[0];	// 2006.08.23 ryoji 前回の置換後文字列を引き継ぐ
 		}

--- a/sakura_core/dlg/CDlgExec.cpp
+++ b/sakura_core/dlg/CDlgExec.cpp
@@ -134,7 +134,7 @@ void CDlgExec::SetData( void )
 	*****************************/
 	hwndCombo = GetItemHwnd( IDC_COMBO_m_szCommand );
 	ApiWrap::Combo_ResetContent( hwndCombo );
-	const int nCommandsCount = m_pShareData->m_sHistory.m_aCommands.size();
+	const auto nCommandsCount = static_cast<int>(m_pShareData->m_sHistory.m_aCommands.count());
 	if( 0 < nCommandsCount ){
 		wcscpy( m_szCommand, m_pShareData->m_sHistory.m_aCommands[0] );
 		ApiWrap::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCommand );
@@ -146,7 +146,7 @@ void CDlgExec::SetData( void )
 
 	hwndCombo = GetItemHwnd( IDC_COMBO_CUR_DIR );
 	ApiWrap::Combo_ResetContent( hwndCombo );
-	const int nCurDirsCount = m_pShareData->m_sHistory.m_aCurDirs.size();
+	const auto nCurDirsCount = static_cast<int>(m_pShareData->m_sHistory.m_aCurDirs.count());
 	if( 0 < nCurDirsCount ){
 		wcscpy( m_szCurDir, m_pShareData->m_sHistory.m_aCurDirs[0] );
 		ApiWrap::DlgItem_SetText( GetHwnd(), IDC_COMBO_TEXT, m_szCurDir );

--- a/sakura_core/dlg/CDlgFind.cpp
+++ b/sakura_core/dlg/CDlgFind.cpp
@@ -64,7 +64,7 @@ BOOL CDlgFind::OnCbnDropDown( HWND hwndCtl, int wID )
 	switch( wID ){
 	case IDC_COMBO_TEXT:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aSearchKeys.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aSearchKeys.count());
 			for (int i = 0; i < nSize; ++i) {
 				ApiWrap::Combo_AddString( hwndCtl, m_pShareData->m_sSearchKeywords.m_aSearchKeys[i] );
 			}

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -250,16 +250,16 @@ int CDlgGrep::DoModal( HINSTANCE hInstance, HWND hwndParent, const WCHAR* pszCur
 
 	// 2013.05.21 コンストラクタからDoModalに移動
 	// m_strText は呼び出し元で設定済み
-	if( m_szFile[0] == L'\0' && m_pShareData->m_sSearchKeywords.m_aGrepFiles.size() ){
+	if (m_szFile[0] == L'\0' && !m_pShareData->m_sSearchKeywords.m_aGrepFiles.empty()) {
 		wcscpy( m_szFile, m_pShareData->m_sSearchKeywords.m_aGrepFiles[0] );		/* 検索ファイル */
 	}
-	if( m_szFolder[0] == L'\0' && m_pShareData->m_sSearchKeywords.m_aGrepFolders.size() ){
+	if (m_szFolder[0] == L'\0' && !m_pShareData->m_sSearchKeywords.m_aGrepFolders.empty()) {
 		wcscpy( m_szFolder, m_pShareData->m_sSearchKeywords.m_aGrepFolders[0] );	/* 検索フォルダー */
 	}
 	
 	/* 除外ファイル */
 	if (m_szExcludeFile[0] == L'\0') {
-		if (m_pShareData->m_sSearchKeywords.m_aExcludeFiles.size()) {
+		if (!m_pShareData->m_sSearchKeywords.m_aExcludeFiles.empty()) {
 			wcscpy(m_szExcludeFile, m_pShareData->m_sSearchKeywords.m_aExcludeFiles[0]);
 		}
 		else {
@@ -273,7 +273,7 @@ int CDlgGrep::DoModal( HINSTANCE hInstance, HWND hwndParent, const WCHAR* pszCur
 
 	/* 除外フォルダー */
 	if (m_szExcludeFolder[0] == L'\0') {
-		if (m_pShareData->m_sSearchKeywords.m_aExcludeFolders.size()) {
+		if (!m_pShareData->m_sSearchKeywords.m_aExcludeFolders.empty()) {
 			wcscpy(m_szExcludeFolder, m_pShareData->m_sSearchKeywords.m_aExcludeFolders[0]);
 		}
 		else {
@@ -571,16 +571,16 @@ BOOL CDlgGrep::OnBnClicked( int wID )
 	case IDCANCEL:
 //		::EndDialog( hwndDlg, FALSE );
 		if (m_bSelectOnceThisText) {
-			if (m_pShareData->m_sSearchKeywords.m_aGrepFiles.size()) {
+			if (!m_pShareData->m_sSearchKeywords.m_aGrepFiles.empty()) {
 				wcsncpy_s(m_szFile, std::size(m_szFile), m_pShareData->m_sSearchKeywords.m_aGrepFiles[0], _TRUNCATE);	/* 検索ファイル */
 			}
-			if (m_pShareData->m_sSearchKeywords.m_aGrepFolders.size()) {
+			if (!m_pShareData->m_sSearchKeywords.m_aGrepFolders.empty()) {
 				wcsncpy_s(m_szFolder, std::size(m_szFolder), m_pShareData->m_sSearchKeywords.m_aGrepFolders[0], _TRUNCATE);	/* 検索フォルダー */
 			}
-			if (m_pShareData->m_sSearchKeywords.m_aExcludeFiles.size()) {
+			if (!m_pShareData->m_sSearchKeywords.m_aExcludeFiles.empty()) {
 				wcsncpy_s(m_szExcludeFile, std::size(m_szExcludeFile), m_pShareData->m_sSearchKeywords.m_aExcludeFiles[0], _TRUNCATE);	/* 除外ファイル */
 			}
-			if (m_pShareData->m_sSearchKeywords.m_aExcludeFolders.size()) {
+			if (!m_pShareData->m_sSearchKeywords.m_aExcludeFolders.empty()) {
 				wcsncpy_s(m_szExcludeFolder, std::size(m_szExcludeFolder), m_pShareData->m_sSearchKeywords.m_aExcludeFolders[0], _TRUNCATE);	/* 除外フォルダー */
 			}
 		}

--- a/sakura_core/dlg/CDlgGrep.cpp
+++ b/sakura_core/dlg/CDlgGrep.cpp
@@ -192,7 +192,7 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 	switch( wID ){
 	case IDC_COMBO_TEXT:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aSearchKeys.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aSearchKeys.count());
 			for( int i = 0; i < nSize; ++i ){
 				ApiWrap::Combo_AddString( hwndCtl, m_pShareData->m_sSearchKeywords.m_aSearchKeys[i] );
 			}
@@ -200,7 +200,7 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 		break;
 	case IDC_COMBO_FILE:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aGrepFiles.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aGrepFiles.count());
 			for( int i = 0; i < nSize; ++i ){
 				ApiWrap::Combo_AddString( hwndCtl, m_pShareData->m_sSearchKeywords.m_aGrepFiles[i] );
 			}
@@ -208,7 +208,7 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 		break;
 	case IDC_COMBO_FOLDER:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aGrepFolders.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aGrepFolders.count());
 			for( int i = 0; i < nSize; ++i ){
 				ApiWrap::Combo_AddString( hwndCtl, m_pShareData->m_sSearchKeywords.m_aGrepFolders[i] );
 			}
@@ -216,7 +216,7 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 		break;
 	case IDC_COMBO_EXCLUDE_FILE:
 		if (::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aExcludeFiles.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aExcludeFiles.count());
 			for (int i = 0; i < nSize; ++i) {
 				ApiWrap::Combo_AddString(hwndCtl, m_pShareData->m_sSearchKeywords.m_aExcludeFiles[i]);
 			}
@@ -224,7 +224,7 @@ BOOL CDlgGrep::OnCbnDropDown( HWND hwndCtl, int wID )
 		break;
 	case IDC_COMBO_EXCLUDE_FOLDER:
 		if (::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aExcludeFolders.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aExcludeFolders.count());
 			for (int i = 0; i < nSize; ++i) {
 				ApiWrap::Combo_AddString(hwndCtl, m_pShareData->m_sSearchKeywords.m_aExcludeFolders[i]);
 			}

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -67,7 +67,7 @@ const DWORD p_helpids[] = {
 
 CDlgGrepReplace::CDlgGrepReplace()
 {
-	if( 0 < m_pShareData->m_sSearchKeywords.m_aReplaceKeys.size() ){
+	if (!m_pShareData->m_sSearchKeywords.m_aReplaceKeys.empty()) {
 		m_strText2 = m_pShareData->m_sSearchKeywords.m_aReplaceKeys[0];
 	}
 	return;
@@ -84,16 +84,16 @@ int CDlgGrepReplace::DoModal( HINSTANCE hInstance, HWND hwndParent, const WCHAR*
 	m_bPaste = false;
 	m_bBackup = m_pShareData->m_Common.m_sSearch.m_bGrepBackup;
 
-	if( m_szFile[0] == L'\0' && m_pShareData->m_sSearchKeywords.m_aGrepFiles.size() ){
+	if (m_szFile[0] == L'\0' && !m_pShareData->m_sSearchKeywords.m_aGrepFiles.empty()) {
 		wcscpy( m_szFile, m_pShareData->m_sSearchKeywords.m_aGrepFiles[0] );		/* 検索ファイル */
 	}
-	if( m_szFolder[0] == L'\0' && m_pShareData->m_sSearchKeywords.m_aGrepFolders.size() ){
+	if (m_szFolder[0] == L'\0' && !m_pShareData->m_sSearchKeywords.m_aGrepFolders.empty()) {
 		wcscpy( m_szFolder, m_pShareData->m_sSearchKeywords.m_aGrepFolders[0] );	/* 検索フォルダー */
 	}
 	
 	/* 除外ファイル */
 	if (m_szExcludeFile[0] == L'\0') {
-		if (m_pShareData->m_sSearchKeywords.m_aExcludeFiles.size()) {
+		if (!m_pShareData->m_sSearchKeywords.m_aExcludeFiles.empty()) {
 			wcscpy(m_szExcludeFile, m_pShareData->m_sSearchKeywords.m_aExcludeFiles[0]);
 		}
 		else {
@@ -107,7 +107,7 @@ int CDlgGrepReplace::DoModal( HINSTANCE hInstance, HWND hwndParent, const WCHAR*
 
 	/* 除外フォルダー */
 	if (m_szExcludeFolder[0] == L'\0') {
-		if (m_pShareData->m_sSearchKeywords.m_aExcludeFolders.size()) {
+		if (!m_pShareData->m_sSearchKeywords.m_aExcludeFolders.empty()) {
 			wcscpy(m_szExcludeFolder, m_pShareData->m_sSearchKeywords.m_aExcludeFolders[0]);
 		}
 		else {

--- a/sakura_core/dlg/CDlgGrepReplace.cpp
+++ b/sakura_core/dlg/CDlgGrepReplace.cpp
@@ -151,7 +151,7 @@ BOOL CDlgGrepReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 	case IDC_COMBO_TEXT2:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
 			const auto& keys = m_pShareData->m_sSearchKeywords.m_aReplaceKeys;
-			for( int i = 0; i < keys.size(); ++i ){
+			for( size_t i = 0; i < keys.count(); ++i ){
 				ApiWrap::Combo_AddString( hwndCtl, keys[i] );
 			}
 		}

--- a/sakura_core/dlg/CDlgReplace.cpp
+++ b/sakura_core/dlg/CDlgReplace.cpp
@@ -80,7 +80,7 @@ BOOL CDlgReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 	switch( wID ){
 	case IDC_COMBO_TEXT:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aSearchKeys.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aSearchKeys.count());
 			for (int i = 0; i < nSize; ++i) {
 				ApiWrap::Combo_AddString( hwndCtl, m_pShareData->m_sSearchKeywords.m_aSearchKeys[i] );
 			}
@@ -88,7 +88,7 @@ BOOL CDlgReplace::OnCbnDropDown( HWND hwndCtl, int wID )
 		break;
 	case IDC_COMBO_TEXT2:
 		if ( ::SendMessage(hwndCtl, CB_GETCOUNT, 0L, 0L) == 0) {
-			int nSize = m_pShareData->m_sSearchKeywords.m_aReplaceKeys.size();
+			const auto nSize = static_cast<int>(m_pShareData->m_sSearchKeywords.m_aReplaceKeys.count());
 			for (int i = 0; i < nSize; ++i) {
 				ApiWrap::Combo_AddString( hwndCtl, m_pShareData->m_sSearchKeywords.m_aReplaceKeys[i] );
 			}

--- a/sakura_core/dlg/CDlgTagJumpList.h
+++ b/sakura_core/dlg/CDlgTagJumpList.h
@@ -145,7 +145,7 @@ private:
 	STagFindState* m_psFindPrev = nullptr; //!< 前回の最後に検索した状態
 	STagFindState* m_psFind0Match = nullptr; //!< 前回の1つもHitしなかった最後のtags
 
-	CNativeW	m_strOldKeyword = { L"" };	//!< 前回のキーワード
+	CNativeW	m_strOldKeyword{ L"" };	//!< 前回のキーワード
 	BOOL	m_bOldTagJumpICase;	//!< 前回の大文字小文字を同一視
 	BOOL	m_bOldTagJumpPartialMatch;	//!< 前回の文字列の途中にマッチ
 

--- a/sakura_core/env/CDataProfile.h
+++ b/sakura_core/env/CDataProfile.h
@@ -15,11 +15,12 @@
 #include "util/StaticType.h"
 
 /*!
- * バッファ参照型
+ * @brief バッファ参照型
  *
  * 読み書き可能なWCHARバッファとサイズを指定して構築する
  */
-using StringBufferW = std::span<WCHAR>;
+template<size_t N>
+using StringBufferW = std::span<WCHAR, N>;
 
 /*!
  * プロファイル用データ変換
@@ -203,108 +204,76 @@ public:
 	using CProfile::SetProfileData;
 
 	 /*!
-	  * Profileから読み込んだ文字列を設定値に変換して取得する
+	  * Profileから読み込んだ文字列をサイズ固定のバッファに読み込む
 	  *
 	  * @retval true 成功
 	  * @retval false 失敗
 	  */
-	template<profile_data::is_supported T>
+	template <size_t N>
 	[[nodiscard]] bool GetProfileData(
-		const std::wstring&		sectionName,	//!< [in] セクション名
-		const std::wstring&		entryKey,		//!< [in] エントリ名
-		T&						tEntryValue		//!< [out] エントリ値
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		std::span<WCHAR, N>		tEntryValue		//!< [in,out] エントリ値
 	) const
 	{
-		if (std::wstring strEntryValue; GetProfileData(sectionName, entryKey, strEntryValue)) {
-			return profile_data::TryParse(strEntryValue, tEntryValue);
+		// 読み込み作業用に可変バッファを用意する
+		std::wstring entryValue;
+		if (!GetProfileData(sectionName, entryKey, entryValue) || N <= entryValue.length()) {
+			return false;	// 指定した設定項目がなかった、または、バッファに入り切らない
 		}
-		return false;
+
+		// 固定長バッファにコピーする
+		::wcscpy_s(std::data(tEntryValue), N, entryValue.c_str());
+
+		return true;
 	}
 
 	/*!
-	 * 設定値を文字列に変換してProfileへ書き込む
-	 */
-	template<profile_data::is_supported T>
-	void SetProfileData(
-		const std::wstring&		sectionName,	//!< [in] セクション名
-		const std::wstring&		entryKey,		//!< [in] エントリ名
-		const T					tEntryValue		//!< [in] エントリ値
-	)
-	{
-		const std::wstring strEntryValue = profile_data::ToString(tEntryValue);
-		SetProfileData(sectionName, entryKey, strEntryValue);
-	}
-
-	/*!
-	 * 設定値の入出力テンプレート
-	 *
-	 * 設定値の入出力を行う。
-	 *
-	 * @retval true	設定値を正しく読み書きできた
-	 * @retval false 設定値を読み込めなかった
-	 */
-	template<profile_data::is_supported T>
-	bool IOProfileData(
-		const std::wstring&		sectionName,	//!< [in] セクション名
-		const std::wstring&		entryKey,		//!< [in] エントリ名
-		T&						tEntryValue		//!< [in,out] エントリ値
-	)
-	{
-		if( IsReadingMode() ){
-			return GetProfileData(sectionName, entryKey, tEntryValue);
-		}else{
-			SetProfileData(sectionName, entryKey, tEntryValue);
-			return true;
-		}
-	}
-
-	/*!
-	 * 設定値の入出力テンプレート
-	 *
-	 * 設定値の入出力を行う。
+	 * 設定値を入出力する
 	 *
 	 * @retval true	設定値を正しく読み書きできた
 	 * @retval false 設定値を読み込めなかった
 	 */
 	bool IOProfileData(
-		const std::wstring&		sectionName,	//!< [in] セクション名
-		const std::wstring&		entryKey,		//!< [in] エントリ名
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
 		std::wstring&			entryValue		//!< [in,out] エントリ値
 	)
 	{
 		if (IsReadingMode()) {
 			return GetProfileData(sectionName, entryKey, entryValue);
-		} else {
-			SetProfileData(sectionName, entryKey, entryValue);
-			return true;
 		}
+		else {
+			SetProfileData(sectionName, entryKey, entryValue);
+		}
+		return true;
 	}
 
 	/*!
-	 * 文字列設定値の入出力
+	 * サイズ制限付き文字列値の入出力
 	 *
-	 * 文字列設定値の入出力を行う。
+	 * サイズ制限付き文字列値の入出力を行う。
 	 *
 	 * @retval true	設定値を正しく読み書きできた
 	 * @retval false 設定値を読み込めなかった
 	 */
+	template <size_t N>
 	bool IOProfileData(
-		const std::wstring&		sectionName,	//!< [in] セクション名
-		const std::wstring&		entryKey,		//!< [in] エントリ名
-		std::span<WCHAR>		tEntryValue		//!< [in,out] エントリ値
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		std::span<WCHAR, N>		tEntryValue		//!< [in,out] エントリ値
 	)
 	{
+		static_assert(1 <= N, "entry size must be greater than 0.");
+
 		if (IsReadingMode()) {
-			std::wstring entryValue;
-			if (!GetProfileData(sectionName, entryKey, entryValue) || std::size(tEntryValue) <= entryValue.length()) {
-				return false;
-			}
-			::wcscpy_s(std::data(tEntryValue), std::size(tEntryValue), std::data(entryValue));
-			return true;
-		} else {
-			SetProfileData(sectionName, entryKey, std::wstring_view{ std::data(tEntryValue), std::size(tEntryValue) });
-			return true;
+			return GetProfileData(sectionName, entryKey, tEntryValue);
 		}
+		else {
+			const auto len = ::wcsnlen(std::data(tEntryValue), N);
+			SetProfileData(sectionName, entryKey, std::wstring_view{ std::data(tEntryValue), len });
+		}
+		return true;
 	}
 
 	/*!
@@ -317,13 +286,43 @@ public:
 	 */
 	template <int N>
 	bool IOProfileData(
-		const std::wstring&		sectionName,	//!< [in] セクション名
-		const std::wstring&		entryKey,		//!< [in] エントリ名
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
 		StaticString<N>&		szEntryValue	//!< [in,out] エントリ値
 	)
 	{
-		// std::span<WCHAR>型に変換して入出力する
-		return IOProfileData(sectionName, entryKey, std::span<WCHAR, N>{ szEntryValue });
+		// std::span<WCHAR, N>型に変換して入出力する
+		return IOProfileData(sectionName, entryKey, StringBufferW(szEntryValue));
+	}
+
+	/*!
+	 * 設定値の入出力テンプレート
+	 *
+	 * 設定値の入出力を行う。
+	 *
+	 * @retval true	設定値を正しく読み書きできた
+	 * @retval false 設定値を読み込めなかった
+	 */
+	template<typename T>
+	bool IOProfileData(
+		std::wstring_view		sectionName,	//!< [in] セクション名
+		std::wstring_view		entryKey,		//!< [in] エントリ名
+		T&						tEntryValue		//!< [in,out] エントリ値
+	)
+	{
+		if (IsReadingMode()) {
+			if (std::wstring strEntryValue;
+				!GetProfileData(sectionName, entryKey, strEntryValue) ||
+				!profile_data::TryParse(strEntryValue, tEntryValue))
+			{
+				return false;
+			}
+		}
+		else {
+			const auto strEntryValue = profile_data::ToString(tEntryValue);
+			SetProfileData(sectionName, entryKey, strEntryValue);
+		}
+		return true;
 	}
 };
 

--- a/sakura_core/env/CDataProfile.h
+++ b/sakura_core/env/CDataProfile.h
@@ -199,6 +199,9 @@ namespace profile_data {
  * @date 2007/09/24 kobake データ変換部を子クラスに分離
  */
 class CDataProfile : public CProfile {
+private:
+	using OptionStr = std::optional<std::wstring>;
+
 public:
 	using CProfile::GetProfileData;
 	using CProfile::SetProfileData;
@@ -322,6 +325,36 @@ public:
 			const auto strEntryValue = profile_data::ToString(tEntryValue);
 			SetProfileData(sectionName, entryKey, strEntryValue);
 		}
+		return true;
+	}
+
+	/*!
+	 * 配列型(StaticVector)の入出力
+	 *
+	 * @retval true	設定値を正しく読み書きできた
+	 * @retval false 設定値を読み込めなかった
+	 */
+	template <typename T, int N, typename A>
+	bool IOProfileDataSet(
+		const std::wstring&		sectionName,	//!< [in] セクション名
+		std::wstring_view		entrySetName,	//!< [in] エントリセット名
+		StaticVector<T, N, A>&	aEntries,		//!< [in,out] エントリ値
+		const OptionStr&		optCountName = std::nullopt
+	)
+	{
+		int count = static_cast<int>(aEntries.count());
+		if (!IOProfileData(sectionName, optCountName.value_or(std::format(L"_{:s}_Counts", entrySetName)), count)) return false;
+
+		if (IsReadingMode()) {
+			count = std::min(std::max(0, count), static_cast<int>(std::size(aEntries)));
+			aEntries.resize(count);
+		}
+
+		for (int i = 0; i < count; ++i) {
+			const auto key = std::format(L"{:s}[{:02d}]", entrySetName, i);
+			IOProfileData(sectionName, key, aEntries[i]);
+		}
+
 		return true;
 	}
 };

--- a/sakura_core/env/CProfile.cpp
+++ b/sakura_core/env/CProfile.cpp
@@ -297,8 +297,8 @@ bool CProfile::_WriteFile(
 	@date 2003-10-22 D.S.Koba 作成
 */
 bool CProfile::GetProfileData(
-	const std::wstring&	sectionName,	//!< [in] セクション名
-	const std::wstring&	entryKey,		//!< [in] エントリ名
+	std::wstring_view	sectionName,	//!< [in] セクション名
+	std::wstring_view	entryKey,		//!< [in] エントリ名
 	std::wstring&		strEntryValue	//!< [out] エントリ値
 ) const
 {
@@ -326,8 +326,8 @@ bool CProfile::GetProfileData(
 	@date 2003-10-21 D.S.Koba 作成
 */
 void CProfile::SetProfileData(
-	const std::wstring&	sectionName,	//!< [in] セクション名
-	const std::wstring&	entryKey,		//!< [in] エントリ名
+	std::wstring_view	sectionName,	//!< [in] セクション名
+	std::wstring_view	entryKey,		//!< [in] エントリ名
 	std::wstring_view	entryValue		//!< [in] エントリ値
 )
 {
@@ -343,7 +343,7 @@ void CProfile::SetProfileData(
 	}
 
 	// エントリに指定された値を書き込む
-	foundSection->m_Entries[entryKey] = entryValue;
+	foundSection->m_Entries[std::wstring(entryKey)] = entryValue;
 }
 
 void CProfile::DUMP( void )

--- a/sakura_core/env/CProfile.h
+++ b/sakura_core/env/CProfile.h
@@ -55,8 +55,17 @@ public:
 	bool ReadProfile(const std::optional<std::filesystem::path>& optProfilePath = std::nullopt) noexcept;
 	bool WriteProfile(const std::optional<std::filesystem::path>& optProfilePath = std::nullopt, const std::optional<std::wstring>& optComment = std::nullopt);
 
-	bool GetProfileData(const std::wstring& sectionName, const std::wstring& entryKey, std::wstring& strEntryValue) const;
-	void SetProfileData(const std::wstring& sectionName, const std::wstring& entryKey, std::wstring_view entryValue);
+	bool GetProfileData(
+		std::wstring_view	sectionName,
+		std::wstring_view	entryKey,
+		std::wstring&		strEntryValue
+	) const;
+
+	void SetProfileData(
+		std::wstring_view	sectionName,
+		std::wstring_view	entryKey,
+		std::wstring_view	entryValue
+	);
 
 	void DUMP( void );
 

--- a/sakura_core/env/CSearchKeywordManager.h
+++ b/sakura_core/env/CSearchKeywordManager.h
@@ -17,12 +17,12 @@
 //共有メモリ内構造体
 struct SShare_SearchKeywords{
 	// -- -- 検索キー -- -- //
-	StaticVector< StaticString<_MAX_PATH>, MAX_SEARCHKEY,  const WCHAR*>	m_aSearchKeys;
-	StaticVector< StaticString<_MAX_PATH>, MAX_REPLACEKEY, const WCHAR*>	m_aReplaceKeys;
-	StaticVector< StaticString<MAX_GREP_PATH>, MAX_GREPFILE,   const WCHAR*>	m_aGrepFiles;
-	StaticVector< StaticString<MAX_GREP_PATH>, MAX_GREPFOLDER, const WCHAR*>	m_aGrepFolders;
-	StaticVector< StaticString<MAX_EXCLUDE_PATH>, MAX_EXCLUDEFILE,   const WCHAR*>	m_aExcludeFiles;
-	StaticVector< StaticString<MAX_EXCLUDE_PATH>, MAX_EXCLUDEFOLDER, const WCHAR*>	m_aExcludeFolders;
+	StaticVector<StaticString<_MAX_PATH>, MAX_SEARCHKEY, std::wstring_view>	m_aSearchKeys;
+	StaticVector<StaticString<_MAX_PATH>, MAX_REPLACEKEY, std::wstring_view>	m_aReplaceKeys;
+	StaticVector<StaticString<MAX_GREP_PATH>, MAX_GREPFILE, std::wstring_view>	m_aGrepFiles;
+	StaticVector<StaticString<MAX_GREP_PATH>, MAX_GREPFOLDER, std::wstring_view>	m_aGrepFolders;
+	StaticVector<StaticString<MAX_EXCLUDE_PATH>, MAX_EXCLUDEFILE, std::wstring_view>	m_aExcludeFiles;
+	StaticVector<StaticString<MAX_EXCLUDE_PATH>, MAX_EXCLUDEFOLDER, std::wstring_view>	m_aExcludeFolders;
 };
 
 //! 検索キーワード管理

--- a/sakura_core/env/CShareData.cpp
+++ b/sakura_core/env/CShareData.cpp
@@ -182,11 +182,11 @@ bool CShareData::InitShareData()
 
 		// マルチユーザー用のiniファイルパス(exe基準の初期化よりも先に行う必要がある)
 		auto privateIniPath = GetIniFileName();
-		m_pShareData->m_szPrivateIniFile = privateIniPath.c_str();
+		m_pShareData->m_szPrivateIniFile = privateIniPath;
 
 		// exe基準のiniファイルパス
 		auto iniPath = GetExeFileName().replace_extension(L".ini");
-		m_pShareData->m_szIniFile = iniPath.c_str();
+		m_pShareData->m_szIniFile = iniPath;
 
 		// 設定ファイルフォルダー
 		WCHAR	szIniFolder[_MAX_PATH];

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -264,7 +264,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 	
 	cProfile.IOProfileData( pszSecName, L"_ExceptMRU_Counts", pShare->m_sHistory.m_aExceptMRU._GetSizeRef() );
 	pShare->m_sHistory.m_aExceptMRU.SetSizeLimit();
-	nSize = pShare->m_sHistory.m_aExceptMRU.size();
+	nSize = static_cast<int>(pShare->m_sHistory.m_aExceptMRU.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"ExceptMRU[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_aExceptMRU[i] );
@@ -288,7 +288,7 @@ void CShareData_IO::ShareData_IO_Keys( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, L"_SEARCHKEY_Counts", pShare->m_sSearchKeywords.m_aSearchKeys._GetSizeRef() );
 	pShare->m_sSearchKeywords.m_aSearchKeys.SetSizeLimit();
-	nSize = pShare->m_sSearchKeywords.m_aSearchKeys.size();
+	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aSearchKeys.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"SEARCHKEY[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aSearchKeys[i] );
@@ -296,7 +296,7 @@ void CShareData_IO::ShareData_IO_Keys( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, L"_REPLACEKEY_Counts", pShare->m_sSearchKeywords.m_aReplaceKeys._GetSizeRef() );
 	pShare->m_sSearchKeywords.m_aReplaceKeys.SetSizeLimit();
-	nSize = pShare->m_sSearchKeywords.m_aReplaceKeys.size();
+	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aReplaceKeys.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"REPLACEKEY[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aReplaceKeys[i] );
@@ -320,7 +320,7 @@ void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, L"_GREPFILE_Counts", pShare->m_sSearchKeywords.m_aGrepFiles._GetSizeRef() );
 	pShare->m_sSearchKeywords.m_aGrepFiles.SetSizeLimit();
-	nSize = pShare->m_sSearchKeywords.m_aGrepFiles.size();
+	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aGrepFiles.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"GREPFILE[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aGrepFiles[i] );
@@ -328,7 +328,7 @@ void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, L"_GREPFOLDER_Counts", pShare->m_sSearchKeywords.m_aGrepFolders._GetSizeRef() );
 	pShare->m_sSearchKeywords.m_aGrepFolders.SetSizeLimit();
-	nSize = pShare->m_sSearchKeywords.m_aGrepFolders.size();
+	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aGrepFolders.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"GREPFOLDER[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aGrepFolders[i] );
@@ -337,7 +337,7 @@ void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 	/* 除外ファイルパターン */
 	cProfile.IOProfileData(pszSecName, L"_GREPEXCLUDEFILE_Counts", pShare->m_sSearchKeywords.m_aExcludeFiles._GetSizeRef());
 	pShare->m_sSearchKeywords.m_aExcludeFiles.SetSizeLimit();
-	nSize = pShare->m_sSearchKeywords.m_aExcludeFiles.size();
+	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aExcludeFiles.count());
 	for (i = 0; i < nSize; ++i) {
 		auto_sprintf(szKeyName, L"GREPEXCLUDEFILE[%02d]", i);
 		cProfile.IOProfileData(pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aExcludeFiles[i]);
@@ -346,7 +346,7 @@ void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 	/* 除外フォルダーパターン */
 	cProfile.IOProfileData(pszSecName, L"_GREPEXCLUDEFOLDER_Counts", pShare->m_sSearchKeywords.m_aExcludeFolders._GetSizeRef());
 	pShare->m_sSearchKeywords.m_aExcludeFolders.SetSizeLimit();
-	nSize = pShare->m_sSearchKeywords.m_aExcludeFolders.size();
+	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aExcludeFolders.count());
 	for (i = 0; i < nSize; ++i) {
 		auto_sprintf(szKeyName, L"GREPEXCLUDEFOLDER[%02d]", i);
 		cProfile.IOProfileData(pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aExcludeFolders[i]);
@@ -386,7 +386,7 @@ void CShareData_IO::ShareData_IO_Cmd( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, L"nCmdArrNum", pShare->m_sHistory.m_aCommands._GetSizeRef() );
 	pShare->m_sHistory.m_aCommands.SetSizeLimit();
-	int nSize = pShare->m_sHistory.m_aCommands.size();
+	int nSize = static_cast<int>(pShare->m_sHistory.m_aCommands.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"szCmdArr[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_aCommands[i] );
@@ -394,7 +394,7 @@ void CShareData_IO::ShareData_IO_Cmd( CDataProfile& cProfile )
 
 	cProfile.IOProfileData( pszSecName, L"nCurDirArrNum", pShare->m_sHistory.m_aCurDirs._GetSizeRef() );
 	pShare->m_sHistory.m_aCurDirs.SetSizeLimit();
-	nSize = pShare->m_sHistory.m_aCurDirs.size();
+	nSize = static_cast<int>(pShare->m_sHistory.m_aCurDirs.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"szCurDirArr[%02d]", i );
 		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_aCurDirs[i] );
@@ -2297,7 +2297,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 	//From Here 2005.04.03 MIK キーワード指定タグジャンプ
 	cProfile.IOProfileData( pszSecName, L"_TagJumpKeyword_Counts", pShare->m_sTagJump.m_aTagJumpKeywords._GetSizeRef() );
 	pShare->m_sHistory.m_aCommands.SetSizeLimit();
-	int nSize = pShare->m_sTagJump.m_aTagJumpKeywords.size();
+	const auto nSize = static_cast<int>(pShare->m_sTagJump.m_aTagJumpKeywords.count());
 	for( i = 0; i < nSize; ++i ){
 		auto_sprintf( szKeyName, L"TagJumpKeyword[%02d]", i );
 		if( i >= nSize ){

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -21,6 +21,8 @@
 #include "_main/CControlProcess.h"
 #include "config/app_constants.h"
 
+using namespace std::literals::string_literals;
+
 using OptionStr = std::optional<std::wstring>;
 
 void ShareData_IO_LogFont(
@@ -1403,35 +1405,32 @@ void CShareData_IO::ShareData_IO_Types( CDataProfile& cProfile )
  * @date 2004/10/02 Moca 対になるコメント設定がともに読み込まれたときだけ有効な設定と見なす．
  * @date 2020/01/01 berryzplus ShareData_IO_Type_Oneから分離
  */
-static bool ShareData_IO_BlockComment( CDataProfile& cProfile,
-	const WCHAR* pszSectionName,
-	const WCHAR* pszEntryKeyFrom,
-	const WCHAR* pszEntryKeyTo,
-	CBlockComment& cBlockComment
-) noexcept
+bool ShareData_IO_BlockComments(
+	CDataProfile&			cProfile,
+	std::wstring_view		sectionName,	//!< [in] セクション名
+	std::wstring_view		entryKey,		//!< [in] エントリ名
+	std::span<CBlockComment>	tEntryValues	//!< [in,out] エントリ値
+)
 {
-	WCHAR szFrom[BLOCKCOMMENT_BUFFERSIZE]{ 0 };
-	WCHAR szTo[BLOCKCOMMENT_BUFFERSIZE]{ 0 };
-
-	// 書き込み準備
-	if( !cProfile.IsReadingMode() ){
-		::wcscpy_s( szFrom, cBlockComment.getBlockCommentFrom() );
-		::wcscpy_s( szTo, cBlockComment.getBlockCommentTo() );
+	for (int i = 0; i < std::size(tEntryValues); ++i) {
+		auto& cBlockComment = tEntryValues[i];
+		const auto keySurfix = 0 < i ? std::to_wstring(i + 1) : L""s;
+		std::wstring strFrom;
+		std::wstring strTo;
+		if (cProfile.IsWritingMode()) {
+			strFrom = cBlockComment.getBlockCommentFrom();
+			strTo = cBlockComment.getBlockCommentTo();
+		}
+		if (!cProfile.IOProfileData(sectionName, std::format(L"{}From{}", entryKey, keySurfix), strFrom)
+			|| !cProfile.IOProfileData(sectionName, std::format(L"{}To{}", entryKey, keySurfix), strTo))
+		{
+			return false;
+		}
+		if (cProfile.IsReadingMode()) {
+			cBlockComment.SetBlockCommentRule(strFrom.c_str(), strTo.c_str());
+		}
 	}
-
-	bool ret = false;
-	if( cProfile.IOProfileData(pszSectionName, pszEntryKeyFrom, StringBufferW(szFrom))
-		&& cProfile.IOProfileData(pszSectionName, pszEntryKeyTo, StringBufferW(szTo)) ){
-		//対になる設定が揃った場合のみ有効
-		ret = true;
-	}
-
-	// 読み込み後処理
-	if( cProfile.IsReadingMode() && ret ){
-		cBlockComment.SetBlockCommentRule( szFrom, szTo );
-	}
-
-	return ret;
+	return true;
 }
 
 /*!
@@ -1580,8 +1579,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	cProfile.IOProfileData( pszSecName, L"bStringEndLine", types.m_bStringEndLine );
 
 	// Block Comment
-	ShareData_IO_BlockComment( cProfile, pszSecName, L"szBlockCommentFrom", L"szBlockCommentTo", types.m_cBlockComments[0] );
-	ShareData_IO_BlockComment( cProfile, pszSecName, L"szBlockCommentFrom2", L"szBlockCommentTo2", types.m_cBlockComments[1] );
+	ShareData_IO_BlockComments( cProfile, pszSecName, L"szBlockComment", std::span(types.m_cBlockComments) );
 
 	// Line Comment
 	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment", L"nLineCommentColumn", types.m_cLineComment, 0 );

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1439,36 +1439,30 @@ bool ShareData_IO_BlockComments(
  * @date 2004/10/02 Moca 対になるコメント設定がともに読み込まれたときだけ有効な設定と見なす．
  * @date 2020/01/01 berryzplus ShareData_IO_Type_Oneから分離
  */
-static bool ShareData_IO_LineComment( CDataProfile& cProfile,
-	const WCHAR* pszSectionName,
-	const WCHAR* pszEntryKeyComment,
-	const WCHAR* pszEntryKeyColumn,
-	CLineComment& cLineComment,
-	const int nDataIndex
-) noexcept
+bool ShareData_IO_LineComments(
+	CDataProfile& cProfile,
+	std::wstring_view		sectionName,	//!< [in] セクション名
+	CLineComment& cLineComment
+)
 {
-	WCHAR lbuf[COMMENT_DELIMITER_BUFFERSIZE]{ 0 };
-	int pos = -1;
-
-	// 書き込み準備
-	if( !cProfile.IsReadingMode() ){
-		::wcscpy_s( lbuf, cLineComment.getLineComment( nDataIndex ) );
-		pos = cLineComment.getLineCommentPos( nDataIndex );
+	for (int i = 0; i < 3; ++i) {
+		const auto keySurfix = 0 < i ? std::to_wstring(i + 1) : L""s;
+		std::wstring lineComment;
+		int pos = -1;
+		if (cProfile.IsWritingMode()) {
+			lineComment = cLineComment.getLineComment(i);
+			pos = cLineComment.getLineCommentPos(i);
+		}
+		if (!cProfile.IOProfileData(sectionName, std::format(L"szLineComment{}", keySurfix), lineComment)
+			|| !cProfile.IOProfileData(sectionName, std::format(L"nLineCommentColumn{}", keySurfix), pos))
+		{
+			return false;
+		}
+		if (cProfile.IsReadingMode()) {
+			cLineComment.CopyTo(i, lineComment.c_str(), pos);
+		}
 	}
-
-	bool ret = false;
-	if( cProfile.IOProfileData(pszSectionName, pszEntryKeyComment, StringBufferW(lbuf))
-		&& cProfile.IOProfileData( pszSectionName, pszEntryKeyColumn, pos ) ){
-		//対になる設定が揃った場合のみ有効
-		ret = true;
-	}
-
-	// 読み込み後処理
-	if( cProfile.IsReadingMode() && ret ){
-		cLineComment.CopyTo( nDataIndex, lbuf, pos );
-	}
-
-	return ret;
+	return true;
 }
 
 /*!
@@ -1582,9 +1576,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 	ShareData_IO_BlockComments( cProfile, pszSecName, L"szBlockComment", std::span(types.m_cBlockComments) );
 
 	// Line Comment
-	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment", L"nLineCommentColumn", types.m_cLineComment, 0 );
-	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment2", L"nLineCommentColumn2", types.m_cLineComment, 1 );
-	ShareData_IO_LineComment( cProfile, pszSecName, L"szLineComment3", L"nLineCommentColumn3", types.m_cLineComment, 2 );
+	ShareData_IO_LineComments( cProfile, pszSecName, types.m_cLineComment );
 
 	cProfile.IOProfileData(pszSecName, L"szIndentChars", StringBufferW(types.m_szIndentChars));
 	cProfile.IOProfileData( pszSecName, L"cLineTermChar"		, types.m_cLineTermChar );

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -21,8 +21,79 @@
 #include "_main/CControlProcess.h"
 #include "config/app_constants.h"
 
-void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
-	const WCHAR* pszKeyLf, const WCHAR* pszKeyPointSize, const WCHAR* pszKeyFaceName, LOGFONT& lf, INT& nPointSize );
+using OptionStr = std::optional<std::wstring>;
+
+void ShareData_IO_LogFont(
+	CDataProfile& cProfile,
+	std::wstring_view pszSecName,
+	std::wstring_view pszKeyLf,
+	LOGFONT& lf,
+	INT& nPointSize,
+	const OptionStr& optPointSizeKey = std::nullopt,
+	const OptionStr& optFaceNameKey = std::nullopt
+)
+{
+	const auto ret1 = cProfile.IOProfileData( pszSecName, optPointSizeKey.value_or(L"nPointSize"), nPointSize);
+
+	std::wstring strEntryValue;
+	if (cProfile.IsWritingMode()) {
+		strEntryValue = std::format(L"{},{},{},{},{},{},{},{},{},{},{},{},{}",
+			lf.lfHeight,
+			lf.lfWidth,
+			lf.lfEscapement,
+			lf.lfOrientation,
+			lf.lfWeight,
+			lf.lfItalic,
+			lf.lfUnderline,
+			lf.lfStrikeOut,
+			lf.lfCharSet,
+			lf.lfOutPrecision,
+			lf.lfClipPrecision,
+			lf.lfQuality,
+			lf.lfPitchAndFamily
+		);
+	}
+
+	const auto ret2 = cProfile.IOProfileData(pszSecName, pszKeyLf, strEntryValue);
+
+	if (ret2 && cProfile.IsReadingMode()) {
+		LOGFONT lfTemp{};
+		if (13 == ::swscanf_s(
+			strEntryValue.c_str(),
+			L"%d,%d,%d,%d,%d,%hhu,%hhu,%hhu,%hhu,%hhu,%hhu,%hhu,%hhu",
+			&lfTemp.lfHeight,
+			&lfTemp.lfWidth,
+			&lfTemp.lfEscapement,
+			&lfTemp.lfOrientation,
+			&lfTemp.lfWeight,
+			&lfTemp.lfItalic,
+			&lfTemp.lfUnderline,
+			&lfTemp.lfStrikeOut,
+			&lfTemp.lfCharSet,
+			&lfTemp.lfOutPrecision,
+			&lfTemp.lfClipPrecision,
+			&lfTemp.lfQuality,
+			&lfTemp.lfPitchAndFamily
+		))
+		{
+			lf = lfTemp;
+
+			if (ret1 && 0 != nPointSize) {
+				// DPI変更してもフォントのポイントサイズが変わらないように
+				// ポイント数からピクセル数に変換する
+				lf.lfHeight = -DpiPointsToPixels( abs(nPointSize), 10 );	// pointSize: 1/10ポイント単位のサイズ
+			}
+			else {
+				// 初回または古いバージョンからの更新時はポイント数をピクセル数から逆算して仮設定
+				nPointSize = DpiPixelsToPoints( abs(lf.lfHeight), 10 );		// （従来フォントダイアログで小数点は指定不可）
+			}
+		}
+	}
+
+	if (ret2) {
+		cProfile.IOProfileData(pszSecName, optFaceNameKey.value_or(std::format(L"{}FaceName", pszKeyLf)), StringBufferW(lf.lfFaceName));
+	}
+}
 
 template <typename T>
 void SetValueLimit(T& target, int minval, int maxval)
@@ -517,8 +588,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	
 	// ai 02/05/23 Add S
 	{// Keword Help Font
-		ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"khlf", L"khps", L"khlfFaceName",
-			common.m_sHelper.m_lf, common.m_sHelper.m_nPointSize );
+		ShareData_IO_LogFont( cProfile, pszSecName, L"khlf", common.m_sHelper.m_lf, common.m_sHelper.m_nPointSize, L"khps" );
 	}// Keword Help Font
 	
 	cProfile.IOProfileData( pszSecName, L"nMRUArrNum_MAX"			, common.m_sGeneral.m_nMRUArrNum_MAX );
@@ -552,8 +622,7 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, L"bTabMultiLine"			, common.m_sTabBar.m_bTabMultiLine );	// タブ多段
 	cProfile.IOProfileData(pszSecName, L"eTabPosition", common.m_sTabBar.m_eTabPosition );	// タブ位置
 
-	ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lfTabFont", L"lfTabFontPs", L"lfTabFaceName",
-		common.m_sTabBar.m_lf, common.m_sTabBar.m_nPointSize );
+	ShareData_IO_LogFont( cProfile, pszSecName, L"lfTabFont", common.m_sTabBar.m_lf, common.m_sTabBar.m_nPointSize, L"lfTabFontPs", L"lfTabFaceName" );
 	
 	cProfile.IOProfileData( pszSecName, L"nTabMaxWidth"			, common.m_sTabBar.m_nTabMaxWidth );
 	cProfile.IOProfileData( pszSecName, L"nTabMinWidth"			, common.m_sTabBar.m_nTabMinWidth );
@@ -943,8 +1012,7 @@ void CShareData_IO::ShareData_IO_Font( CDataProfile& cProfile )
 
 	const WCHAR* pszSecName = L"Font";
 	CommonSetting_View& view = pShare->m_Common.m_sView;
-	ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lf", L"nPointSize", L"lfFaceName",
-		view.m_lf, view.m_nPointSize );
+	ShareData_IO_LogFont( cProfile, pszSecName, L"lf", view.m_lf, view.m_nPointSize );
 
 	cProfile.IOProfileData( pszSecName, L"bFontIs_FIXED_PITCH", view.m_bFontIs_FIXED_PITCH );
 }
@@ -1232,13 +1300,11 @@ void CShareData_IO::ShareData_IO_Print( CDataProfile& cProfile )
 			auto_sprintf( szKeyName,  L"PS[%02d].lfHeader",			i );
 			auto_sprintf( szKeyName2, L"PS[%02d].nHeaderPointSize",	i );
 			auto_sprintf( szKeyName3, L"PS[%02d].lfHeaderFaceName",	i );
-			ShareData_IO_Sub_LogFont( cProfile, pszSecName, szKeyName,szKeyName2, szKeyName3,
-				printsetting.m_lfHeader, printsetting.m_nHeaderPointSize );
+			ShareData_IO_LogFont( cProfile, pszSecName, szKeyName, printsetting.m_lfHeader, printsetting.m_nHeaderPointSize, szKeyName2, szKeyName3 );
 			auto_sprintf( szKeyName,  L"PS[%02d].lfFooter",			i );
 			auto_sprintf( szKeyName2, L"PS[%02d].nFooterPointSize",	i );
 			auto_sprintf( szKeyName3, L"PS[%02d].lfFooterFaceName",	i );
-			ShareData_IO_Sub_LogFont( cProfile, pszSecName, szKeyName,szKeyName2, szKeyName3,
-				printsetting.m_lfFooter, printsetting.m_nFooterPointSize );
+			ShareData_IO_LogFont( cProfile, pszSecName, szKeyName, printsetting.m_lfFooter, printsetting.m_nFooterPointSize, szKeyName2, szKeyName3 );
 		}
 
 		auto_sprintf( szKeyName, L"PS[%02d].szDriver", i );
@@ -1747,8 +1813,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 
 	{ // フォント設定
 		cProfile.IOProfileData( pszSecName, L"bUseTypeFont", types.m_bUseTypeFont );
-		ShareData_IO_Sub_LogFont( cProfile, pszSecName, L"lf", L"nPointSize", L"lfFaceName",
-			types.m_lf, types.m_nPointSize );
+		ShareData_IO_LogFont( cProfile, pszSecName, L"lf", types.m_lf, types.m_nPointSize );
 	}
 }
 
@@ -2319,61 +2384,6 @@ void CShareData_IO::IO_ColorSet( CDataProfile* pcProfile, const WCHAR* pszSecNam
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                         実装補助                            //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
-void ShareData_IO_Sub_LogFont( CDataProfile& cProfile, const WCHAR* pszSecName,
-	const WCHAR* pszKeyLf, const WCHAR* pszKeyPointSize, const WCHAR* pszKeyFaceName, LOGFONT& lf, INT& nPointSize )
-{
-	const WCHAR* pszForm = L"%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d";
-	WCHAR		szKeyData[1024];
-
-	cProfile.IOProfileData( pszSecName, pszKeyPointSize, nPointSize );	// 2009.10.01 ryoji
-	if( cProfile.IsReadingMode() ){
-		if( cProfile.IOProfileData(pszSecName, pszKeyLf, StringBufferW(szKeyData)) ){
-			int buf[13];
-			scan_ints( szKeyData, pszForm, buf );
-			lf.lfHeight			= buf[ 0];
-			lf.lfWidth			= buf[ 1];
-			lf.lfEscapement		= buf[ 2];
-			lf.lfOrientation	= buf[ 3];
-			lf.lfWeight			= buf[ 4];
-			lf.lfItalic			= (BYTE)buf[ 5];
-			lf.lfUnderline		= (BYTE)buf[ 6];
-			lf.lfStrikeOut		= (BYTE)buf[ 7];
-			lf.lfCharSet		= (BYTE)buf[ 8];
-			lf.lfOutPrecision	= (BYTE)buf[ 9];
-			lf.lfClipPrecision	= (BYTE)buf[10];
-			lf.lfQuality		= (BYTE)buf[11];
-			lf.lfPitchAndFamily	= (BYTE)buf[12];
-			if( nPointSize != 0 ){
-				// DPI変更してもフォントのポイントサイズが変わらないように
-				// ポイント数からピクセル数に変換する
-				lf.lfHeight = -DpiPointsToPixels( abs(nPointSize), 10 );	// pointSize: 1/10ポイント単位のサイズ
-			}else{
-				// 初回または古いバージョンからの更新時はポイント数をピクセル数から逆算して仮設定
-				nPointSize = DpiPixelsToPoints( abs(lf.lfHeight), 10 );		// （従来フォントダイアログで小数点は指定不可）
-			}
-		}
-	}else{
-		auto_sprintf( szKeyData, pszForm,
-			lf.lfHeight,
-			lf.lfWidth,
-			lf.lfEscapement,
-			lf.lfOrientation,
-			lf.lfWeight,
-			lf.lfItalic,
-			lf.lfUnderline,
-			lf.lfStrikeOut,
-			lf.lfCharSet,
-			lf.lfOutPrecision,
-			lf.lfClipPrecision,
-			lf.lfQuality,
-			lf.lfPitchAndFamily
-		);
-		cProfile.IOProfileData(pszSecName, pszKeyLf, StringBufferW(szKeyData));
-	}
-	
-	cProfile.IOProfileData(pszSecName, pszKeyFaceName, StringBufferW(lf.lfFaceName));
-}
-
 void CShareData_IO::ShareData_IO_FileTree( CDataProfile& cProfile, SFileTree& fileTree, const WCHAR* pszSecName )
 {
 	cProfile.IOProfileData( pszSecName, L"bFileTreeProject", fileTree.m_bProject );

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -262,13 +262,7 @@ void CShareData_IO::ShareData_IO_Mru( CDataProfile& cProfile )
 		}
 	}
 	
-	cProfile.IOProfileData( pszSecName, L"_ExceptMRU_Counts", pShare->m_sHistory.m_aExceptMRU._GetSizeRef() );
-	pShare->m_sHistory.m_aExceptMRU.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sHistory.m_aExceptMRU.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"ExceptMRU[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_aExceptMRU[i] );
-	}
+	cProfile.IOProfileDataSet( pszSecName, L"ExceptMRU", pShare->m_sHistory.m_aExceptMRU );
 }
 
 /*!
@@ -282,25 +276,9 @@ void CShareData_IO::ShareData_IO_Keys( CDataProfile& cProfile )
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
 	const WCHAR* pszSecName = L"Keys";
-	int		i;
-	int		nSize;
-	WCHAR	szKeyName[64];
 
-	cProfile.IOProfileData( pszSecName, L"_SEARCHKEY_Counts", pShare->m_sSearchKeywords.m_aSearchKeys._GetSizeRef() );
-	pShare->m_sSearchKeywords.m_aSearchKeys.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aSearchKeys.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"SEARCHKEY[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aSearchKeys[i] );
-	}
-
-	cProfile.IOProfileData( pszSecName, L"_REPLACEKEY_Counts", pShare->m_sSearchKeywords.m_aReplaceKeys._GetSizeRef() );
-	pShare->m_sSearchKeywords.m_aReplaceKeys.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aReplaceKeys.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"REPLACEKEY[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aReplaceKeys[i] );
-	}
+	cProfile.IOProfileDataSet( pszSecName, L"SEARCHKEY",  pShare->m_sSearchKeywords.m_aSearchKeys );
+	cProfile.IOProfileDataSet( pszSecName, L"REPLACEKEY", pShare->m_sSearchKeywords.m_aReplaceKeys );
 }
 
 /*!
@@ -314,43 +292,11 @@ void CShareData_IO::ShareData_IO_Grep( CDataProfile& cProfile )
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
 	const WCHAR* pszSecName = L"Grep";
-	int		i;
-	int		nSize;
-	WCHAR	szKeyName[64];
 
-	cProfile.IOProfileData( pszSecName, L"_GREPFILE_Counts", pShare->m_sSearchKeywords.m_aGrepFiles._GetSizeRef() );
-	pShare->m_sSearchKeywords.m_aGrepFiles.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aGrepFiles.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"GREPFILE[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aGrepFiles[i] );
-	}
-
-	cProfile.IOProfileData( pszSecName, L"_GREPFOLDER_Counts", pShare->m_sSearchKeywords.m_aGrepFolders._GetSizeRef() );
-	pShare->m_sSearchKeywords.m_aGrepFolders.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aGrepFolders.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"GREPFOLDER[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aGrepFolders[i] );
-	}
-
-	/* 除外ファイルパターン */
-	cProfile.IOProfileData(pszSecName, L"_GREPEXCLUDEFILE_Counts", pShare->m_sSearchKeywords.m_aExcludeFiles._GetSizeRef());
-	pShare->m_sSearchKeywords.m_aExcludeFiles.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aExcludeFiles.count());
-	for (i = 0; i < nSize; ++i) {
-		auto_sprintf(szKeyName, L"GREPEXCLUDEFILE[%02d]", i);
-		cProfile.IOProfileData(pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aExcludeFiles[i]);
-	}
-
-	/* 除外フォルダーパターン */
-	cProfile.IOProfileData(pszSecName, L"_GREPEXCLUDEFOLDER_Counts", pShare->m_sSearchKeywords.m_aExcludeFolders._GetSizeRef());
-	pShare->m_sSearchKeywords.m_aExcludeFolders.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sSearchKeywords.m_aExcludeFolders.count());
-	for (i = 0; i < nSize; ++i) {
-		auto_sprintf(szKeyName, L"GREPEXCLUDEFOLDER[%02d]", i);
-		cProfile.IOProfileData(pszSecName, szKeyName, pShare->m_sSearchKeywords.m_aExcludeFolders[i]);
-	}
+	cProfile.IOProfileDataSet( pszSecName, L"GREPFILE",          pShare->m_sSearchKeywords.m_aGrepFiles );
+	cProfile.IOProfileDataSet( pszSecName, L"GREPFOLDER",        pShare->m_sSearchKeywords.m_aGrepFolders );
+	cProfile.IOProfileDataSet( pszSecName, L"GREPEXCLUDEFILE",   pShare->m_sSearchKeywords.m_aExcludeFiles );
+	cProfile.IOProfileDataSet( pszSecName, L"GREPEXCLUDEFOLDER", pShare->m_sSearchKeywords.m_aExcludeFolders );
 }
 
 /*!
@@ -381,24 +327,10 @@ void CShareData_IO::ShareData_IO_Cmd( CDataProfile& cProfile )
 	DLLSHAREDATA* pShare = &GetDllShareData();
 
 	const WCHAR* pszSecName = L"Cmd";
-	int		i;
-	WCHAR	szKeyName[64];
 
-	cProfile.IOProfileData( pszSecName, L"nCmdArrNum", pShare->m_sHistory.m_aCommands._GetSizeRef() );
-	pShare->m_sHistory.m_aCommands.SetSizeLimit();
-	int nSize = static_cast<int>(pShare->m_sHistory.m_aCommands.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"szCmdArr[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_aCommands[i] );
-	}
+	cProfile.IOProfileDataSet( pszSecName, L"szCmdArr",    pShare->m_sHistory.m_aCommands, L"nCmdArrNum" );
 
-	cProfile.IOProfileData( pszSecName, L"nCurDirArrNum", pShare->m_sHistory.m_aCurDirs._GetSizeRef() );
-	pShare->m_sHistory.m_aCurDirs.SetSizeLimit();
-	nSize = static_cast<int>(pShare->m_sHistory.m_aCurDirs.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"szCurDirArr[%02d]", i );
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sHistory.m_aCurDirs[i] );
-	}
+	cProfile.IOProfileDataSet( pszSecName, L"szCurDirArr", pShare->m_sHistory.m_aCurDirs, L"nCurDirArrNum" );
 }
 
 /*!
@@ -2303,16 +2235,7 @@ void CShareData_IO::ShareData_IO_Other( CDataProfile& cProfile )
 	cProfile.IOProfileData(pszSecName, L"szTagsCmdLine", StringBufferW(pShare->m_szTagsCmdLine));
 	
 	//From Here 2005.04.03 MIK キーワード指定タグジャンプ
-	cProfile.IOProfileData( pszSecName, L"_TagJumpKeyword_Counts", pShare->m_sTagJump.m_aTagJumpKeywords._GetSizeRef() );
-	pShare->m_sHistory.m_aCommands.SetSizeLimit();
-	const auto nSize = static_cast<int>(pShare->m_sTagJump.m_aTagJumpKeywords.count());
-	for( i = 0; i < nSize; ++i ){
-		auto_sprintf( szKeyName, L"TagJumpKeyword[%02d]", i );
-		if( i >= nSize ){
-			pShare->m_sTagJump.m_aTagJumpKeywords[i][0] = L'\0';
-		}
-		cProfile.IOProfileData( pszSecName, szKeyName, pShare->m_sTagJump.m_aTagJumpKeywords[i] );
-	}
+	cProfile.IOProfileDataSet( pszSecName, L"TagJumpKeyword",        pShare->m_sTagJump.m_aTagJumpKeywords );
 	cProfile.IOProfileData( pszSecName, L"m_bTagJumpICase"		, pShare->m_sTagJump.m_bTagJumpICase );
 	cProfile.IOProfileData( pszSecName, L"m_bTagJumpAnyWhere"	, pShare->m_sTagJump.m_bTagJumpPartialMatch);
 	//From Here 2005.04.03 MIK キーワード指定タグジャンプの

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -1770,7 +1770,7 @@ void CShareData_IO::ShareData_IO_Type_One( CDataProfile& cProfile, STypeConfig& 
 							wcsncpy_s( types.m_KeyHelpArr[j].m_szAbout, pH, _TRUNCATE );
 							pH = pT+1;
 							if( L'\0' != (*pH) ){
-								types.m_KeyHelpArr[j].m_szPath = pH;
+								types.m_KeyHelpArr[j].m_szPath = std::wstring_view(pH);
 								types.m_nKeyHelpNum = j+1;	// iniに保存せずに、読み出せたファイル分を辞書数とする
 							}
 						}

--- a/sakura_core/env/CShareData_IO.cpp
+++ b/sakura_core/env/CShareData_IO.cpp
@@ -435,32 +435,40 @@ void CShareData_IO::ShareData_IO_Nickname( CDataProfile& cProfile )
 	}
 }
 
-static bool ShareData_IO_RECT( CDataProfile& cProfile, const WCHAR* pszSecName, const WCHAR* pszKeyName, RECT& rcValue )
+/*!
+ * 矩形データの入出力を行う。
+ */
+template<>
+bool CDataProfile::IOProfileData<RECT>(
+	std::wstring_view		sectionName,	//!< [in] セクション名
+	std::wstring_view		entryKey,		//!< [in] エントリ名
+	RECT&					tEntryValue		//!< [in,out] エントリ値
+)
 {
-	const WCHAR* pszForm = L"%d,%d,%d,%d";
-	WCHAR		szKeyData[100];
-	bool		ret = false;
-	if( cProfile.IsReadingMode() ){
-		ret = cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
-		if( ret ){
-			int buf[4];
-			scan_ints( szKeyData, pszForm, buf );
-			rcValue.left	= buf[0];
-			rcValue.top		= buf[1];
-			rcValue.right	= buf[2];
-			rcValue.bottom	= buf[3];
-		}
-	}else{
-		auto_sprintf(
-			szKeyData,
-			pszForm,
-			rcValue.left,
-			rcValue.top,
-			rcValue.right,
-			rcValue.bottom
-		);
-		ret = cProfile.IOProfileData(pszSecName, pszKeyName, StringBufferW(szKeyData));
+	std::wstring strEntryValue;
+	if (IsWritingMode()) {
+		strEntryValue = std::format(L"{},{},{},{}", tEntryValue.left, tEntryValue.top, tEntryValue.right, tEntryValue.bottom);
 	}
+
+	const auto ret = IOProfileData(sectionName, entryKey, strEntryValue);
+
+	if (ret && IsReadingMode()) {
+		CMyRect rc{};
+		if (4 != ::swscanf_s(
+			strEntryValue.c_str(),
+			L"%d,%d,%d,%d",
+			&rc.left,
+			&rc.top,
+			&rc.right,
+			&rc.bottom
+		))
+		{
+			return false;
+		}
+
+		tEntryValue = rc;
+	}
+
 	return ret;
 }
 
@@ -697,12 +705,12 @@ void CShareData_IO::ShareData_IO_Common( CDataProfile& cProfile )
 	cProfile.IOProfileData( pszSecName, L"nAlertFileSize"				, common.m_sFile.m_nAlertFileSize );	// 警告を開始するファイルサイズ(MB単位)
 	
 	/* 「開く」ダイアログのサイズと位置 */
-	ShareData_IO_RECT( cProfile,  pszSecName, L"rcOpenDialog", common.m_sOthers.m_rcOpenDialog );
-	ShareData_IO_RECT( cProfile,  pszSecName, L"rcCompareDialog", common.m_sOthers.m_rcCompareDialog );
-	ShareData_IO_RECT( cProfile,  pszSecName, L"rcDiffDialog", common.m_sOthers.m_rcDiffDialog );
-	ShareData_IO_RECT( cProfile,  pszSecName, L"rcFavoriteDialog", common.m_sOthers.m_rcFavoriteDialog );
-	ShareData_IO_RECT( cProfile,  pszSecName, L"rcTagJumpDialog", common.m_sOthers.m_rcTagJumpDialog );
-	ShareData_IO_RECT( cProfile,  pszSecName, L"rcWindowListDialog", common.m_sOthers.m_rcWindowListDialog );
+	cProfile.IOProfileData( pszSecName, L"rcOpenDialog", common.m_sOthers.m_rcOpenDialog );
+	cProfile.IOProfileData( pszSecName, L"rcCompareDialog", common.m_sOthers.m_rcCompareDialog );
+	cProfile.IOProfileData( pszSecName, L"rcDiffDialog", common.m_sOthers.m_rcDiffDialog );
+	cProfile.IOProfileData( pszSecName, L"rcFavoriteDialog", common.m_sOthers.m_rcFavoriteDialog );
+	cProfile.IOProfileData( pszSecName, L"rcTagJumpDialog", common.m_sOthers.m_rcTagJumpDialog );
+	cProfile.IOProfileData( pszSecName, L"rcWindowListDialog", common.m_sOthers.m_rcWindowListDialog );
 	
 	//2002.02.08 aroka,hor
 	cProfile.IOProfileData( pszSecName, L"bMarkUpBlankLineEnable"	, common.m_sOutline.m_bMarkUpBlankLineEnable );

--- a/sakura_core/env/CWriteManager.cpp
+++ b/sakura_core/env/CWriteManager.cpp
@@ -34,7 +34,7 @@ EConvertResult CWriteManager::WriteFile_From_CDocLineMgr(
 
 	{
 		// 変換テスト
-		CNativeW buffer = L"abcde";
+		CNativeW buffer{ L"abcde" };
 		CMemory tmp;
 		EConvertResult e = pcCodeBase->UnicodeToCode( buffer, &tmp );
 		if(e==RESULT_FAILURE){

--- a/sakura_core/macro/CMacro.cpp
+++ b/sakura_core/macro/CMacro.cpp
@@ -473,7 +473,7 @@ void CMacro::Save( HINSTANCE hInstance, CTextOutputStream& out ) const
 				cmemWork.Replace( L"\r", L"\\r" );
 				cmemWork.Replace( L"\n", L"\\n" );
 				cmemWork.Replace( L"\t", L"\\t" );
-				cmemWork.Replace( L"\0", 1, L"\\u0000", 6 );
+				cmemWork.Replace( std::wstring_view(L"\0", 1), std::wstring_view(L"\\u0000", 6) );
 				cmemWork.Replace( L"\u0085", L"\\u0085" );
 				cmemWork.Replace( L"\u2028", L"\\u2028" );
 				cmemWork.Replace( L"\u2029", L"\\u2029" );

--- a/sakura_core/mem/CNativeW.cpp
+++ b/sakura_core/mem/CNativeW.cpp
@@ -59,9 +59,9 @@ CNativeW::CNativeW( const wchar_t* pData, size_t nDataLen )
 	SetString( pData, nDataLen );
 }
 
-CNativeW::CNativeW( const wchar_t* pData )
+CNativeW::CNativeW(std::wstring_view text)
 {
-	SetString(pData);
+	SetString(std::data(text), std::size(text));
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -75,14 +75,9 @@ void CNativeW::SetString( const wchar_t* pData, size_t nDataLen )
 }
 
 // バッファの内容を置き換える
-void CNativeW::SetString( const wchar_t* pszData )
+void CNativeW::SetString( std::wstring_view data )
 {
-	if( pszData != nullptr ){
-		std::wstring_view data(pszData);
-		SetString( data.data(), data.length() );
-	}else{
-		Reset();
-	}
+	SetString( data.data(), data.length() );
 }
 
 void CNativeW::SetStringHoldBuffer( const wchar_t* pData, size_t nDataLen )
@@ -167,29 +162,55 @@ void CNativeW::AppendNativeData( const CNativeW& cmemData )
  * 指定した文字列を連結した文字列バッファを作成する
  *
  * @param lhs 文字列バッファ(CNativeW)
- * @param rhs 文字列ポインタ(C string)
+ * @param rhs 文字列(std::wstring_view)
  * @return 新しい文字列バッファ
  * @throws std::bad_alloc メモリ確保に失敗した
  */
-CNativeW operator + (const CNativeW& lhs, const wchar_t* rhs) noexcept(false)
+CNativeW operator + (const CNativeW& lhs, std::wstring_view rhs) noexcept(false)
 {
 	CNativeW tmp(lhs);
-	tmp.AppendString(rhs);
-	return tmp;
+	return (tmp += rhs);
 }
 
 /*!
  * 指定した文字列を連結した文字列バッファを作成する
  *
- * @param lhs 文字列ポインタ(C string)
- * @param rhs 文字列バッファ(CNativeW)
+ * @param lhs 文字列バッファ(CNativeW)
+ * @param rhs 文字列(std::wstring_view)
  * @return 新しい文字列バッファ
  * @throws std::bad_alloc メモリ確保に失敗した
  */
-CNativeW operator + (const wchar_t* lhs, const CNativeW& rhs) noexcept(false)
+CNativeW operator + (std::wstring_view lhs, const CNativeW& rhs) noexcept(false)
 {
 	CNativeW tmp(lhs);
-	return tmp + rhs;
+	return (tmp += rhs);
+}
+
+/*!
+ * 指定した文字列を連結する
+ *
+ * @param lhs 文字列バッファ(CNativeW)
+ * @param rhs 文字列(std::wstring_view)
+ * @return 文字列バッファ
+ * @throws std::bad_alloc メモリ確保に失敗した
+ */
+CNativeW& operator += (CNativeW& lhs, std::wstring_view rhs) noexcept(false)
+{
+	lhs.AppendString(rhs);
+	return lhs;
+}
+
+/*!
+ * 指定した文字を連結する
+ *
+ * @param lhs 文字列バッファ(CNativeW)
+ * @param rhs 文字(wchar_t)
+ * @return 文字列バッファ
+ * @throws std::bad_alloc メモリ確保に失敗した
+ */
+CNativeW& operator += (CNativeW& lhs, wchar_t rhs) noexcept(false)
+{
+	return (lhs += std::wstring_view(&rhs, 1));
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -223,108 +244,62 @@ CNativeW operator + (const wchar_t* lhs, const CNativeW& rhs) noexcept(false)
 int CNativeW::Compare(const CNativeW& rhs) const noexcept
 {
 	if (this == &rhs) return 0;
-	const int lhsIsValid = static_cast<int>(IsValid());
-	const int rhsIsValid = static_cast<int>(rhs.IsValid());
-	if (!rhsIsValid || !lhsIsValid) return lhsIsValid - rhsIsValid;
-	// データ長が短い方を基準に比較を行う
-	const int lhsLength = static_cast<int>(GetStringLength());
-	const int rhsLength = static_cast<int>(rhs.GetStringLength());
-	const int minLength = std::min(lhsLength, rhsLength);
-	// データ長の範囲で文字列を比較する
-	auto cmp = wmemcmp(GetStringPtr(), rhs.GetStringPtr(), minLength);
-	if (!cmp) cmp = lhsLength - rhsLength;
-	return cmp;
-}
-
-/*!
- * 文字列ポインタ型との比較
- *
- * @param rhs 比較対象(C string)
- * @retval < 0 自身がメモリ未確保、かつ、比較対象がnullptr以外
- * @retval < 0 文字列値が比較対象より小さい
- * @retval == 0 比較対象と等しい
- * @retval == 0 自身がメモリ未確保、かつ、比較対象がnullptr
- * @retval > 0 自身がメモリ確保済み、かつ、比較対象がnullptr
- * @retval > 0 文字列値が比較対象より大きい
- */
-int CNativeW::Compare(const wchar_t* rhs) const noexcept
-{
-	const int lhsIsValid = static_cast<int>(IsValid());
-	const int rhsIsValid = rhs ? 1 : 0;
-	if (!rhsIsValid || !lhsIsValid) return lhsIsValid - rhsIsValid;
-	const wchar_t* lhs = GetStringPtr();
-	const size_t lhsLength = GetStringLength();
-	// NUL終端考慮のために終端を拡張し、比較自体はCRTに丸投げする
-	return wcsncmp(lhs, rhs, lhsLength + 1);
+	const auto lhsValid = IsValid();
+	const auto rhsValid = rhs.IsValid();
+	if (!lhsValid && !rhsValid) return 0;
+	if (!lhsValid) return -1;
+	if (!rhsValid) return 1;
+	const auto lhs = static_cast<std::wstring_view>(*this);
+	return lhs.compare(rhs);
 }
 
 /* 等しい内容か */
 bool CNativeW::IsEqual( const CNativeW& cmem1, const CNativeW& cmem2 )
 {
-	if(&cmem1==&cmem2)return true;
-
-	const int nLen1 = cmem1.GetStringLength();
-	const int nLen2 = cmem2.GetStringLength();
-	if( nLen1 == nLen2 ){
-		const wchar_t* psz1 = cmem1.GetStringPtr();
-		const wchar_t* psz2 = cmem2.GetStringPtr();
-		if( 0 == wmemcmp( psz1, psz2, nLen1 ) ){
-			return true;
-		}
-	}
-	return false;
+	return cmem1.Equals(cmem2);
 }
 
 /*!
- * 文字列ポインタ型との等価比較
+ * 同型との等価比較
  *
  * @param lhs 比較対象(CNativeW)
- * @param rhs 比較対象(C string)
+ * @param rhs 比較対象(CNativeW)
  * @retval true 等しい
  * @retval false 等しくない
  */
-bool operator == (const CNativeW& lhs, const wchar_t* rhs) noexcept
+bool operator == (const CNativeW& lhs, const CNativeW& rhs) noexcept
 {
 	return lhs.Equals(rhs);
 }
 
 /*!
- * 文字列ポインタ型との否定の等価比較
+ * 文字列との等価比較
  *
  * @param lhs 比較対象(CNativeW)
- * @param rhs 比較対象(C string)
- * @retval true 等しくない
- * @retval false 等しい
- */
-bool operator != (const CNativeW& lhs, const wchar_t* rhs) noexcept
-{
-	return !(lhs == rhs);
-}
-
-/*!
- * 文字列ポインタ型との等価比較(引数逆転版)
- *
- * @param lhs 比較対象(C string)
- * @param rhs 比較対象(CNativeW)
+ * @param rhs 比較対象(std::wstring_view)
  * @retval true 等しい
  * @retval false 等しくない
  */
-bool operator == (const wchar_t* lhs, const CNativeW& rhs) noexcept
+bool operator == (const CNativeW& lhs, std::wstring_view rhs) noexcept(false)
 {
-	return rhs.Equals(lhs);
+	return 0 == lhs.Compare(rhs);
 }
 
 /*!
- * 文字列ポインタ型との否定の等価比較(引数逆転版)
+ * 文字列ポインタとの等価比較
  *
- * @param lhs 比較対象(C string)
- * @param rhs 比較対象(CNativeW)
- * @retval true 等しくない
- * @retval false 等しい
+ * @param lhs 比較対象(CNativeW)
+ * @param rhs 比較対象(C String)
+ * @retval true 等しい
+ * @retval false 等しくない
  */
-bool operator != (const wchar_t* lhs, const CNativeW& rhs) noexcept
+bool operator == (const CNativeW& lhs, LPCWSTR rhs) noexcept(false)
 {
-	return !(lhs == rhs);
+	// rhsがNULLでない場合、文字列として比較する
+	if (rhs) return (lhs == std::wstring_view(rhs));
+
+	// rhsがNULLの場合、メモリ未確保を等しいとみなす
+	return !lhs.IsValid();
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -353,11 +328,6 @@ void CNativeW::Replace( std::wstring_view strFrom, std::wstring_view strTo )
 		cmemWork.AppendString( &GetStringPtr()[nBgnOld], GetStringLength() - nBgnOld );
 	}
 	SetRawDataHoldBuffer( cmemWork );
-}
-
-void CNativeW::Replace( const wchar_t* pszFrom, size_t nFromLen, const wchar_t* pszTo, size_t nToLen )
-{
-	Replace( std::wstring_view( pszFrom, nFromLen ), std::wstring_view( pszTo, nToLen ) );
 }
 
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -59,16 +59,24 @@ private:
 };
 
 // グローバル演算子の前方宣言
-bool operator == (const CNativeW& lhs, const wchar_t* rhs) noexcept;
-bool operator != (const CNativeW& lhs, const wchar_t* rhs) noexcept;
-bool operator == (const wchar_t* lhs, const CNativeW& rhs) noexcept;
-bool operator != (const wchar_t* lhs, const CNativeW& rhs) noexcept;
-CNativeW operator + (const CNativeW& lhs, const wchar_t* rhs) noexcept(false);
-CNativeW operator + (const wchar_t* lhs, const CNativeW& rhs) noexcept(false);
+bool operator == (const CNativeW& lhs, const CNativeW& rhs) noexcept;
+bool operator == (const CNativeW& lhs, std::wstring_view rhs);
+bool operator == (const CNativeW& lhs, LPCWSTR rhs);
+CNativeW operator + (const CNativeW& lhs, std::wstring_view rhs) noexcept(false);
+CNativeW operator + (std::wstring_view lhs, const CNativeW& rhs) noexcept(false);
+CNativeW& operator += (CNativeW& lhs, std::wstring_view rhs) noexcept(false);
+CNativeW& operator += (CNativeW& lhs, wchar_t rhs) noexcept(false);
 
 //! UNICODE文字列管理クラス
 class CNativeW final : public CNative{
-	friend bool operator == (const CNativeW& lhs, const wchar_t* rhs) noexcept;
+private:
+	friend bool operator == (const CNativeW& lhs, const CNativeW& rhs) noexcept;
+	friend bool operator == (const CNativeW& lhs, std::wstring_view rhs) noexcept(false);
+	friend bool operator == (const CNativeW& lhs, LPCWSTR rhs) noexcept(false);
+	friend CNativeW operator + (const CNativeW& lhs, std::wstring_view rhs) noexcept(false);
+	friend CNativeW operator + (std::wstring_view lhs, const CNativeW& rhs) noexcept(false);
+	friend CNativeW& operator += (CNativeW& lhs, std::wstring_view rhs) noexcept(false);
+	friend CNativeW& operator += (CNativeW& lhs, wchar_t rhs) noexcept(false);
 
 	using Me = CNativeW;
 
@@ -77,8 +85,7 @@ public:
 	CNativeW() noexcept = default;
 	CNativeW( const wchar_t* pData, size_t nDataLen ); //!< nDataLenは文字単位。
 
-	// TODO: いつかexplicitを付ける
-	CNativeW( const wchar_t* pData );
+	explicit CNativeW(std::wstring_view text);
 
 	/*! メモリ確保済みかどうか */
 	[[nodiscard]] bool IsValid() const noexcept { return GetStringPtr() != nullptr; }
@@ -88,7 +95,7 @@ public:
 
 	//WCHAR
 	void SetString( const wchar_t* pData, size_t nDataLen );			//!< バッファの内容を置き換える。nDataLenは文字単位。
-	void SetString( const wchar_t* pszData );							//!< バッファの内容を置き換える。
+	void SetString( std::wstring_view data );							//!< バッファの内容を置き換える。
 	void SetStringHoldBuffer( const wchar_t* pData, size_t nDataLen );
 	void AppendString( const wchar_t* pszData, size_t nDataLen );		//!< バッファの最後にデータを追加する。nLengthは文字単位。成功すればtrue。メモリ確保に失敗したらfalseを返す。
 	void AppendString( std::wstring_view data );						//!< バッファの最後にデータを追加する
@@ -97,13 +104,6 @@ public:
 	//CNativeW
 	void SetNativeData( const CNativeW& cNative );						//!< バッファの内容を置き換える
 	void AppendNativeData( const CNativeW& cNative );					//!< バッファの最後にデータを追加する
-
-	//演算子
-	CNativeW  operator + (const CNativeW& rhs) const	{ return (CNativeW(*this) += rhs); }
-	CNativeW& operator += (const CNativeW& rhs)			{ AppendNativeData(rhs); return *this; }
-	CNativeW& operator += (wchar_t ch)					{ return (*this += CNativeW(&ch, 1)); }
-	bool operator == (const CNativeW& rhs) const noexcept { return 0 == Compare(rhs); }
-	bool operator != (const CNativeW& rhs) const noexcept { return !(*this == rhs); }
 
 	//ネイティブ取得インターフェース
 	[[nodiscard]] wchar_t operator[]( size_t nIndex ) const;                    //!< 任意位置の文字取得。nIndexは文字単位。
@@ -160,10 +160,9 @@ public:
 	//                           判定                              //
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 	
-	int Compare(const CNativeW& rhs) const noexcept;
-	int Compare(const wchar_t* rhs) const noexcept;
-	bool Equals(const CNativeW& rhs) const noexcept { return 0 == Compare(rhs); }
-	bool Equals(const wchar_t* rhs) const noexcept { return 0 == Compare(rhs); }
+	int		Compare(const CNativeW& rhs) const noexcept;
+	int		Compare(std::wstring_view rhs) const { return Compare(CNativeW(rhs)); }
+	bool	Equals(const CNativeW& rhs) const noexcept { return 0 == Compare(rhs); }
 
 	//! 同一の文字列ならtrue
 	static bool IsEqual( const CNativeW& cmem1, const CNativeW& cmem2 );
@@ -173,18 +172,14 @@ public:
 	// -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 
 	void Replace( std::wstring_view strFrom, std::wstring_view strTo );   //!< 文字列置換
-	void Replace( const wchar_t* pszFrom, size_t nFromLen, const wchar_t* pszTo, size_t nToLen );   //!< 文字列置換
 
 	/*!
 	 * @brief 文字列を代入する演算子
 	 *
-	 * implicitなコンストラクタと競合するので追加できない。
-	 *
 	 * @param rhs [in] 代入元文字列
 	 * @return 自分自身への参照
 	 */
-	 // TODO: いつかコメントインする
-	//Me& operator = (std::wstring_view rhs) noexcept { SetString(rhs.data(), rhs.length()); return *this; }
+	Me& operator = (std::wstring_view rhs) noexcept { SetString(rhs.data(), rhs.length()); return *this; }
 
 	Me& operator = (const std::wstring& rhs) noexcept { return operator = (static_cast<std::wstring_view>(rhs)); }
 	Me& operator = (const std::filesystem::path& path) noexcept { return operator = (path.native()); }

--- a/sakura_core/mem/CNativeW.h
+++ b/sakura_core/mem/CNativeW.h
@@ -1,7 +1,7 @@
 ﻿/*! @file */
 /*
 	Copyright (C) 2008, kobake
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -17,6 +17,7 @@
 class CNativeW;
 
 //! 文字列への参照を保持するクラス
+// TODO: いつか廃止する
 class CStringRef final{
 public:
 	CStringRef() noexcept = default;
@@ -28,6 +29,29 @@ public:
 	[[nodiscard]] bool IsValid() const noexcept { return m_pData != nullptr; }
 	[[nodiscard]] wchar_t At( size_t nIndex ) const noexcept;
 	[[nodiscard]] wchar_t operator []( size_t nIndex ) const noexcept { return m_pData[nIndex]; }
+
+	/*!
+	 * @brief 文字列が空かどうか調べる
+	 */
+	constexpr bool empty() const noexcept { return 0 == length(); }
+
+	/*!
+	 * @brief 文字列長を取得する
+	 */
+	constexpr size_t length() const noexcept
+	{
+		return static_cast<size_t>(m_nDataLen);
+	}
+
+	/*!
+	 * @brief 文字列参照に変換する
+	 *
+	 * explicitを付けないのはC++の作法に照らして適切でない。
+	 * C++への移行を加速させるために仮置き。
+	 *
+	 * @return 文字列参照
+	 */
+	constexpr /* implicit */ operator std::wstring_view()   const & noexcept { return std::wstring_view{ m_pData, m_nDataLen }; }
 
 private:
 	const wchar_t*	m_pData = nullptr;
@@ -46,10 +70,14 @@ CNativeW operator + (const wchar_t* lhs, const CNativeW& rhs) noexcept(false);
 class CNativeW final : public CNative{
 	friend bool operator == (const CNativeW& lhs, const wchar_t* rhs) noexcept;
 
+	using Me = CNativeW;
+
 public:
 	//コンストラクタ・デストラクタ
 	CNativeW() noexcept = default;
 	CNativeW( const wchar_t* pData, size_t nDataLen ); //!< nDataLenは文字単位。
+
+	// TODO: いつかexplicitを付ける
 	CNativeW( const wchar_t* pData );
 
 	/*! メモリ確保済みかどうか */
@@ -90,6 +118,19 @@ public:
 	wchar_t* GetStringPtr()
 	{
 		return reinterpret_cast<wchar_t*>(GetRawPtr());
+	}
+
+	/*!
+	 * @brief 文字列が空かどうか調べる
+	 */
+	bool empty() const noexcept { return 0 == length(); }
+
+	/*!
+	 * @brief 文字列長を取得する
+	 */
+	size_t length() const noexcept
+	{
+		return static_cast<size_t>(GetStringLength());
 	}
 
 	//特殊
@@ -133,6 +174,42 @@ public:
 
 	void Replace( std::wstring_view strFrom, std::wstring_view strTo );   //!< 文字列置換
 	void Replace( const wchar_t* pszFrom, size_t nFromLen, const wchar_t* pszTo, size_t nToLen );   //!< 文字列置換
+
+	/*!
+	 * @brief 文字列を代入する演算子
+	 *
+	 * implicitなコンストラクタと競合するので追加できない。
+	 *
+	 * @param rhs [in] 代入元文字列
+	 * @return 自分自身への参照
+	 */
+	 // TODO: いつかコメントインする
+	//Me& operator = (std::wstring_view rhs) noexcept { SetString(rhs.data(), rhs.length()); return *this; }
+
+	Me& operator = (const std::wstring& rhs) noexcept { return operator = (static_cast<std::wstring_view>(rhs)); }
+	Me& operator = (const std::filesystem::path& path) noexcept { return operator = (path.native()); }
+
+	/*!
+	 * @brief 文字列を代入する演算子
+	 *
+	 * @param rhs [in] 代入元文字列
+	 * @return 自分自身への参照
+	 */
+	template<size_t N>
+	Me& operator = (const WCHAR (&rhs)[N]) noexcept
+	{
+		return operator = (std::wstring_view(rhs, N - 1));
+	}
+
+	/*!
+	 * @brief 文字列参照に変換する
+	 *
+	 * explicitを付けないのはC++の作法に照らして適切でない。
+	 * C++への移行を加速させるために仮置き。
+	 *
+	 * @return 文字列参照
+	 */
+	/* implicit */ operator std::wstring_view() const & noexcept { return std::wstring_view(GetStringPtr(), static_cast<size_t>(GetStringLength())); }
 
 public:
 	// -- -- staticインターフェース -- -- //

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -487,7 +487,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 				}
 				if( cProfile.ReadProfile(pszIniFileName) ){
 					CImpExpFileTree::IO_FileTreeIni(cProfile, m_fileTreeSetting.m_aItems);
-					m_fileTreeSetting.m_szLoadProjectIni = pszIniFileName;
+					m_fileTreeSetting.m_szLoadProjectIni = std::wstring_view(pszIniFileName);
 				}
 			}
 			SetDataInit();
@@ -740,7 +740,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 						SFileTreeItem item;
 						item.m_eFileTreeItemType = EFileTreeItemType_File;
 						item.m_szTargetPath = cmemFile;
-						item.m_szLabelName = GetFileTitlePointer(aFileNames[i].c_str());
+						item.m_szLabelName = std::wstring_view(GetFileTitlePointer(aFileNames[i].c_str()));
 						htiInsert = InsertTreeItem(item, htiParent, htiInsert);
 						if( htiItemFirst == nullptr ){
 							htiItemFirst = htiInsert;

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -740,7 +740,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 						SFileTreeItem item;
 						item.m_eFileTreeItemType = EFileTreeItemType_File;
 						item.m_szTargetPath = cmemFile;
-						item.m_szLabelName = std::wstring_view(GetFileTitlePointer(aFileNames[i].c_str()));
+						item.m_szLabelName = std::filesystem::path(aFileNames[i]).filename();
 						htiInsert = InsertTreeItem(item, htiParent, htiInsert);
 						if( htiItemFirst == nullptr ){
 							htiItemFirst = htiInsert;

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -535,7 +535,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 					std::vector<LPCWSTR>(), std::vector<LPCWSTR>() );
 				WCHAR szFile[_MAX_PATH];
 				if( dlg.DoModal_GetOpenFileName(szFile) ){
-					CNativeW cmemFile = szFile;
+					CNativeW cmemFile{ szFile };
 					cmemFile.Replace(L"%", L"%%");
 					ApiWrap::DlgItem_SetText( GetHwnd(), IDC_EDIT_PATH, cmemFile.GetStringPtr() );
 				}
@@ -735,7 +735,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 					}
 					HTREEITEM htiItemFirst = nullptr;
 					for( int i = 0; i < (int)aFileNames.size(); i++ ){
-						CNativeW cmemFile = aFileNames[i].c_str();
+						CNativeW cmemFile{ aFileNames[i] };
 						cmemFile.Replace(L"%", L"%%");
 						SFileTreeItem item;
 						item.m_eFileTreeItemType = EFileTreeItemType_File;

--- a/sakura_core/outline/CDlgFileTree.cpp
+++ b/sakura_core/outline/CDlgFileTree.cpp
@@ -739,7 +739,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 						cmemFile.Replace(L"%", L"%%");
 						SFileTreeItem item;
 						item.m_eFileTreeItemType = EFileTreeItemType_File;
-						item.m_szTargetPath = cmemFile.GetStringPtr();
+						item.m_szTargetPath = cmemFile;
 						item.m_szLabelName = GetFileTitlePointer(aFileNames[i].c_str());
 						htiInsert = InsertTreeItem(item, htiParent, htiInsert);
 						if( htiItemFirst == nullptr ){
@@ -773,7 +773,7 @@ BOOL CDlgFileTree::OnBnClicked( int wID )
 						CNativeW str(item.m_szTargetPath);
 						str.Replace(szPathFrom, szPathTo);
 						if( str.GetStringLength() < (int)item.m_szTargetPath.GetBufferCount() ){
-							item.m_szTargetPath = str.GetStringPtr();
+							item.m_szTargetPath = str;
 						}
 					}
 				}

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3930,7 +3930,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 			}
 			if( cProfile.ReadProfile(pszIniFileName) ){
 				CImpExpFileTree::IO_FileTreeIni(cProfile, data.m_aItems);
-				data.m_szLoadProjectIni = pszIniFileName;
+				data.m_szLoadProjectIni = std::wstring_view(pszIniFileName);
 				bReadIni = true;
 			}
 		}

--- a/sakura_core/outline/CDlgFuncList.cpp
+++ b/sakura_core/outline/CDlgFuncList.cpp
@@ -3907,7 +3907,7 @@ void CDlgFuncList::LoadFileTreeSetting( CFileTreeSetting& data, SFilePath& IniDi
 				data.m_eFileTreeSettingLoadType = EFileTreeSettingFrom_File;
 				IniDirPath = szPath;
 				CutLastYenFromDirectoryPath( IniDirPath );
-				data.m_szLoadProjectIni = strIniFileName.c_str();
+				data.m_szLoadProjectIni = strIniFileName;
 				break;
 			}
 			CDlgTagJumpList::DirUp( szPath );

--- a/sakura_core/recent/CMRUFile.cpp
+++ b/sakura_core/recent/CMRUFile.cpp
@@ -198,7 +198,7 @@ void CMRUFile::Add( EditInfo* pEditInfo )
 	
 	// すでに登録されている場合は、除外指定を無視する
 	if( -1 == m_cRecentFile.FindItemByPath( pEditInfo->m_szPath ) ){
-		int nSize = m_pShareData->m_sHistory.m_aExceptMRU.size();
+		const auto nSize = static_cast<int>(m_pShareData->m_sHistory.m_aExceptMRU.count());
 		for( int i = 0 ; i < nSize; i++ ){
 			WCHAR szExceptMRU[_MAX_PATH];
 			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, int(std::size(szExceptMRU)) );

--- a/sakura_core/recent/CMRUFolder.cpp
+++ b/sakura_core/recent/CMRUFolder.cpp
@@ -127,7 +127,7 @@ void CMRUFolder::Add( const WCHAR* pszFolder )
 
 	// すでに登録されている場合は、除外指定を無視する
 	if( -1 == m_cRecentFolder.FindItemByText( pszFolder ) ){
-		int nSize = m_pShareData->m_sHistory.m_aExceptMRU.size();
+		const auto nSize = static_cast<int>(m_pShareData->m_sHistory.m_aExceptMRU.count());
 		for( int i = 0 ; i < nSize; i++ ){
 			WCHAR szExceptMRU[_MAX_PATH];
 			CFileNameManager::ExpandMetaToFolder( m_pShareData->m_sHistory.m_aExceptMRU[i], szExceptMRU, int(std::size(szExceptMRU)) );

--- a/sakura_core/recent/SShare_History.h
+++ b/sakura_core/recent/SShare_History.h
@@ -24,7 +24,7 @@ struct SShare_History{
 	bool							m_bOPENFOLDERArrFavorite[MAX_OPENFOLDER];	//お気に入り	//@@@ 2003.04.08 MIK
 
 	//MRU除外リスト一覧
-	StaticVector< StaticString<_MAX_PATH>, MAX_MRU,  const WCHAR* >	m_aExceptMRU;
+	StaticVector<StaticString<_MAX_PATH>, MAX_MRU, std::wstring_view>	m_aExceptMRU;
 
 	//MRU以外の情報
 	SFilePath													m_szIMPORTFOLDER;	// インポートディレクトリの履歴

--- a/sakura_core/typeprop/CImpExpManager.cpp
+++ b/sakura_core/typeprop/CImpExpManager.cpp
@@ -812,7 +812,7 @@ bool CImpExpKeyHelp::Import( const std::wstring& sFileName, std::wstring& sErrMs
 		//良さそうなら
 		m_Types.m_KeyHelpArr[i].m_bUse = (b_enable_flag!=0);	// 2007.02.03 genta
 		wcsncpy_s(m_Types.m_KeyHelpArr[i].m_szAbout, p4, _TRUNCATE);	// 2026.06.23 bounded copy (defense in depth)
-		m_Types.m_KeyHelpArr[i].m_szPath = p3;				// 2026.06.23 StaticString::operator= copies with bounds + NUL
+		m_Types.m_KeyHelpArr[i].m_szPath = std::wstring_view(p3);
 		i++;
 	}
 	in.Close();

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -229,13 +229,36 @@ private:
 	ArrayType	m_aElements{};
 };
 
-//! ヒープを用いない文字列クラス
-//2007.09.23 kobake 作成。
+/*!
+ * @brief ヒープを用いない文字列クラス
+ *
+ * 固定長の文字バッファをクラス内部に保持する文字列クラス。
+ * ヒープ領域を使用しないため、共有メモリに配置できる。
+ * 既存コードにある生配列を最小の変更で置き換えるために、
+ * C++の作法に照らして不適切な演算子を多く定義している。
+ *
+ * @code{.cpp}
+ * using SFilePath = StaticString<_MAX_PATH>;
+ * SFilePath filePath{};
+ *
+ * // 以下と同等。
+ * WCHAR szFilePath[_MAX_PATH] {};
+ * @endcode
+ *
+ * @tparam N_BUFFER_COUNT バッファの要素数。文字列長 + 1（ヌル文字）以上を指定すること。
+ *
+ * @author kobake
+ * @date 2007.09.23 kobake 作成
+ */
 template <int N_BUFFER_COUNT>
-class StaticString{
+// TODO: final指定したいが継承クラスがあるのでコメントアウトしている
+class StaticString /* final */ {
 private:
 	//テンプレート定数名が長過ぎて不便なので、エイリアスを切る
 	static constexpr auto N = N_BUFFER_COUNT;
+
+	// 文字バッファの要素数は 1以上 を想定する
+	static_assert(1 <= N, "N_BUFFER_COUNT must be greater than 0.");
 
 	using ArrayType = std::array<WCHAR, N>;
 	using Traits = std::char_traits<WCHAR>;
@@ -249,10 +272,39 @@ public:
 
 	//コンストラクタ・デストラクタ
 	StaticString() = default;
-	constexpr explicit StaticString(std::wstring_view src) { assign(src); }
 
 	/*!
-	 * 文字列を末尾に追加する
+	 * @brief 文字列をコピーして構築する
+	 *
+	 * @param source [in] 割り当てる文字列への参照
+	 */
+	constexpr explicit StaticString(
+		std::wstring_view source
+	) noexcept
+	{
+		assign(source);
+	}
+
+	/*!
+	 * @brief 文字配列をコピーして構築する
+	 *
+	 * 配列の要素数が内部バッファの要素数を超える場合はコンパイルエラーになる。
+	 *
+	 * @tparam Size コピー元配列の要素数
+	 * @param source [in] 割り当てる文字列
+	 */
+	template<std::size_t Size>
+	constexpr explicit StaticString(const WCHAR (&source)[Size]) noexcept
+	{
+		// コピー元配列が長過ぎる場合、コンパイルエラーにする
+		constexpr auto Length = Size - 1;
+		static_assert(Length < size(), "source string is too long.");
+
+		assign(std::wstring_view(source, Length));
+	}
+
+	/*!
+	 * @brief 文字列を末尾に追加する
 	 *
 	 * @retval 0 成功
 	 * @retval STRUNCATE 切り詰め発生
@@ -267,7 +319,7 @@ public:
 	}
 
 	/*!
-	 * 文字列を代入する
+	 * @brief 文字列を代入する
 	 *
 	 * @retval 0 成功
 	 * @retval STRUNCATE 切り詰め発生
@@ -281,7 +333,10 @@ public:
 	}
 
 	/*!
-	 * 文字列長を取得する
+	 * @brief 文字列長を取得する
+	 *
+	 * @note 毎回再計算するので効率は良くない。
+	 * @note 長さを頻繁に確認する用途ではstd::wstringへの移行を検討すること。
 	 */
 	constexpr size_t length() const noexcept
 	{
@@ -301,15 +356,36 @@ public:
 	constexpr const WCHAR* data()  const noexcept { return std::data(m_szData); }
 	constexpr const WCHAR* c_str() const noexcept { return data(); }
 
-	constexpr operator std::span<WCHAR, N>()       & noexcept { return std::span<WCHAR, N>{ data(), N }; }
-	constexpr operator std::wstring_view()   const & noexcept { return std::wstring_view{ data(), length() }; }
-	constexpr operator std::span<WCHAR>()          & noexcept { return operator std::span<WCHAR, N>(); }
+	constexpr explicit		 operator std::span<WCHAR, N>()       & noexcept { return std::span<WCHAR, N>{ data(), N }; }
+	constexpr /* implicit */ operator std::span<WCHAR>()          & noexcept { return operator std::span<WCHAR, N>(); }
+	constexpr /* implicit */ operator std::wstring_view()   const & noexcept { return std::wstring_view{ data(), length() }; }
 
 	explicit operator std::filesystem::path() const & noexcept { return static_cast<std::wstring_view>(*this); }
 
 	constexpr Me& operator = (std::wstring_view rhs) noexcept { assign(rhs); return *this; }
 	constexpr Me& operator = (const std::wstring& rhs) noexcept { assign(rhs); return *this; }
-	constexpr Me& operator = (const std::filesystem::path& path) noexcept { assign(path.wstring()); return *this; }
+	Me& operator = (const std::filesystem::path& path) noexcept { assign(path.native()); return *this; }
+
+	/*!
+	 * @brief 文字配列を代入する
+	 *
+	 * 代入元配列の要素数が内部バッファの要素数を超える場合はコンパイルエラーになる。
+	 *
+	 * @tparam Size 代入元配列の要素数
+	 * @param rhs [in] 代入元配列
+	 * @return 自分自身への参照
+	 */
+	template<std::size_t Size>
+	constexpr Me& operator = (const WCHAR (&rhs)[Size]) noexcept
+	{
+		// 代入元配列が長過ぎる場合、コンパイルエラーにする
+		constexpr auto Length = Size - 1;
+		static_assert(Length < size(), "source string is too long.");
+
+		assign(std::wstring_view(rhs, Length));
+
+		return *this;
+	}
 
 	constexpr Me& operator += (std::wstring_view rhs) noexcept { append(rhs); return *this; }
 	constexpr Me& operator += (const std::wstring& rhs) noexcept { append(rhs); return *this; }
@@ -322,13 +398,34 @@ public:
 	const WCHAR* GetBufferPointer() const{ return data(); }
 
 	//簡易データアクセス
-	constexpr operator       WCHAR*()       & noexcept { return data(); }
-	constexpr operator const WCHAR*() const & noexcept { return data(); }
+	constexpr /* implicit */ operator       WCHAR*()       & noexcept { return data(); }
+	constexpr /* implicit */ operator const WCHAR*() const & noexcept { return data(); }
 
 	WCHAR At(int nIndex) const{ return m_szData[nIndex]; }
 
 	//簡易コピー
+	/*!
+	 * @brief ポインタを指定して文字列を割り当てる
+	 *
+	 * @param src [in, opt] 割り当てる文字列を指すポインタ。
+	 *
+	 * @note 引数にはNULLを指定できる
+	 * @note NULLチェックの責任が分散してしまうので廃止予定。
+	 */
+	// TODO: いつか廃止する
+	// TODO: いつか以下のC++属性をコメントインする
+	// [[deprecated("Use assign() instead.")]]
 	void Assign(const WCHAR* src) noexcept { assign(std::wstring_view{ src ? src : L"" }); }
+
+	/*!
+	 * @brief ポインタを指定して文字列を割り当てる
+	 *
+	 * @param src [in, opt] 割り当てる文字列を指すポインタ。
+	 *
+	 * @note 引数にはNULLを指定できる
+	 * @note NULLチェックの責任が分散してしまうので廃止予定。
+	 */
+	// TODO: いつか廃止する
 	Me& operator = (const WCHAR* src){ Assign(src); return *this; }
 
 	//各種メソッド

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -25,8 +25,6 @@
  *
  * 有効要素数と固定長バッファをクラス内部に保持する可変長配列クラス。
  * ヒープ領域を使用しないため、共有メモリに配置できる。
- * 既存コードにある生配列を最小の変更で置き換えるために、
- * C++の作法に照らして不適切な演算子を多く定義している。
  *
  * @code{.cpp}
  * using SMruList = StaticVector<SFilePath, 50>;
@@ -98,10 +96,9 @@ public:
 	constexpr       auto* data()        noexcept { return std::data(m_aElements); }
 	constexpr const auto* data()  const noexcept { return std::data(m_aElements); }
 
-	constexpr explicit		 operator std::span<ElementType, size()>() & noexcept { return std::span<ElementType, size()>(data(), size()); }
-	constexpr /* implicit */ operator std::span<ElementType>() & noexcept { return operator std::span<ElementType, size()>(); }
-	constexpr /* implicit */ operator std::span<const ElementType>() const & noexcept { return std::span(data(), count()); }
-	constexpr /* implicit */ operator const ElementType*() const & noexcept { return data(); }
+	constexpr explicit operator std::span<ElementType, size()>() & noexcept { return std::span<ElementType, size()>(data(), size()); }
+	constexpr explicit operator std::span<ElementType>() & noexcept { return operator std::span<ElementType, size()>(); }
+	constexpr explicit operator std::span<const ElementType>() const & noexcept { return std::span<const ElementType, size()>(data(), count()); }
 
 	//要素アクセス
 	/*!

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -417,17 +417,6 @@ public:
 	// [[deprecated("Use assign() instead.")]]
 	void Assign(const WCHAR* src) noexcept { assign(std::wstring_view{ src ? src : L"" }); }
 
-	/*!
-	 * @brief ポインタを指定して文字列を割り当てる
-	 *
-	 * @param src [in, opt] 割り当てる文字列を指すポインタ。
-	 *
-	 * @note 引数にはNULLを指定できる
-	 * @note NULLチェックの責任が分散してしまうので廃止予定。
-	 */
-	// TODO: いつか廃止する
-	Me& operator = (const WCHAR* src){ Assign(src); return *this; }
-
 	//各種メソッド
 	int Length() const noexcept { return static_cast<int>(length()); }
 

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -37,26 +37,26 @@
  * SFilePath aMruFileArr[50] {};
  * @endcode
  *
- * @tparam ELEMENT_TYPE 要素型。
- * @tparam MAX_SIZE バッファの要素数。
- * @tparam SET_TYPE push_backで追加する型。
+ * @tparam T 要素型。
+ * @tparam N バッファの要素数。
+ * @tparam A push_backで追加する型。
  *
  * @author kobake
  * @date 2007.09.23 kobake 作成
  */
-template <class ELEMENT_TYPE, int MAX_SIZE, class SET_TYPE = const ELEMENT_TYPE&>
+template <class T, int N, class A = const T&>
 class StaticVector final {
 public:
 	//型
-	using ElementType = ELEMENT_TYPE;
+	using ElementType = T;
 
 private:
-	using ArrayType = std::array<ElementType, MAX_SIZE>;
+	using ArrayType = std::array<T, N>;
 
-	using Me = StaticVector<ElementType, MAX_SIZE, SET_TYPE>;
+	using Me = StaticVector<T, N, A>;
 
 public:
-	static constexpr size_t size() noexcept { return MAX_SIZE; }
+	static constexpr size_t size() noexcept { return N; }
 
 	StaticVector() = default;
 
@@ -161,7 +161,7 @@ public:
 		m_aElements[countOld] = ElementType(std::forward<Args>(args)...);
 	}
 
-	void push_back(SET_TYPE e)
+	void push_back(A e)
 	{
 		// 変更前の有効要素数を取得する
 		const auto countOld = m_nCount;

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -56,7 +56,7 @@ private:
 	using Me = StaticVector<ElementType, MAX_SIZE, SET_TYPE>;
 
 public:
-	static int max_size() noexcept { return MAX_SIZE; }
+	static constexpr size_t size() noexcept { return MAX_SIZE; }
 
 	StaticVector() = default;
 
@@ -68,8 +68,8 @@ public:
 	{
 		// 要素数がバッファサイズを越えたら例外を投げる
 		const auto sourceSize = std::size(source);
-		if (static_cast<size_t>(MAX_SIZE) < sourceSize) {
-			throw std::out_of_range(std::format("source has too many elements. (elements: {}, allowed: {})", sourceSize, MAX_SIZE));
+		if (size() < sourceSize) {
+			throw std::out_of_range(std::format("source has too many elements. (elements: {}, allowed: {})", sourceSize, size()));
 		}
 
 		m_nCount = static_cast<int>(sourceSize);
@@ -86,19 +86,21 @@ public:
 	}
 
 	//属性
-	constexpr int size() const noexcept { return m_nCount; }
+	constexpr size_t count() const noexcept { return m_nCount; }
+	constexpr bool empty() const noexcept { return 0 == m_nCount; }
 
 	constexpr auto begin() noexcept { return m_aElements.begin(); }
-	constexpr auto end() noexcept { return m_aElements.begin() + MAX_SIZE; }
+	constexpr auto end() noexcept { return m_aElements.begin() + size(); }
 
 	auto begin() const noexcept { return m_aElements.begin(); }
-	auto end() const noexcept { return m_aElements.begin() + m_nCount; }
+	auto end() const noexcept { return m_aElements.begin() + count(); }
 
 	constexpr       auto* data()        noexcept { return std::data(m_aElements); }
 	constexpr const auto* data()  const noexcept { return std::data(m_aElements); }
 
-	constexpr explicit		 operator std::span<ElementType, MAX_SIZE>() & noexcept { return std::span<ElementType, MAX_SIZE>{ data(), MAX_SIZE }; }
-	constexpr /* implicit */ operator std::span<ElementType>() & noexcept { return operator std::span<ElementType, MAX_SIZE>(); }
+	constexpr explicit		 operator std::span<ElementType, size()>() & noexcept { return std::span<ElementType, size()>(data(), size()); }
+	constexpr /* implicit */ operator std::span<ElementType>() & noexcept { return operator std::span<ElementType, size()>(); }
+	constexpr /* implicit */ operator std::span<const ElementType>() const & noexcept { return std::span(data(), count()); }
 	constexpr /* implicit */ operator const ElementType*() const & noexcept { return data(); }
 
 	//要素アクセス
@@ -112,8 +114,8 @@ public:
 	constexpr ElementType& operator[](size_t nIndex)
 	{
 		// 有効要素数を越えたら例外を投げる
-		if (size_t(m_nCount) <= nIndex) {
-			throw std::out_of_range(std::format("nIndex is out of range. (nIndex: {}, allowed: {})", nIndex, m_nCount - 1));
+		if (count() <= nIndex) {
+			throw std::out_of_range(std::format("nIndex is out of range. (nIndex: {}, allowed: {})", nIndex, count() - 1));
 		}
 
 		return m_aElements[nIndex];
@@ -129,8 +131,8 @@ public:
 	constexpr const ElementType& operator[](size_t nIndex) const
 	{
 		// バッファサイズを越えたら例外を投げる
-		if (size_t(MAX_SIZE) <= nIndex) {
-			throw std::out_of_range(std::format("nIndex is out of range. (nIndex: {}, allowed: {})", nIndex, MAX_SIZE - 1));
+		if (size() <= nIndex) {
+			throw std::out_of_range(std::format("nIndex is out of range. (nIndex: {}, allowed: {})", nIndex, size() - 1));
 		}
 
 		return m_aElements[nIndex];
@@ -180,8 +182,8 @@ public:
 	constexpr void resize(size_t nNewSize)
 	{
 		// バッファサイズを越えたら例外を投げる
-		if (size_t(MAX_SIZE) < nNewSize) {
-			throw std::out_of_range(std::format("nNewSize is out of range. (nNewSize: {}, allowed: {})", nNewSize, MAX_SIZE - 1));
+		if (size() < nNewSize) {
+			throw std::out_of_range(std::format("nNewSize is out of range. (nNewSize: {}, allowed: {})", nNewSize, size() - 1));
 		}
 		m_nCount = static_cast<int>(nNewSize);
 	}
@@ -211,9 +213,13 @@ public:
 	 */
 	 // TODO: いつか廃止する
 	void SetSizeLimit(){
-		if( MAX_SIZE < m_nCount ){
-			m_nCount = MAX_SIZE;
-		}else if( m_nCount < 0 ){
+		if (const auto maxSize = static_cast<int>(size());
+			maxSize < m_nCount)
+		{
+			m_nCount = maxSize;
+		}
+		else if (m_nCount < 0)
+		{
 			m_nCount = 0;
 		}
 	}

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -12,10 +12,40 @@
 #include "util/string_ex.h"
 #include "debug/Debug2.h"
 
-//! ヒープを用いないvector
-//2007.09.23 kobake 作成。
+#include <array>
+#include <initializer_list>
+#include <ranges>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+/*!
+ * @brief ヒープを用いない可変長配列クラス
+ *
+ * 有効要素数と固定長バッファをクラス内部に保持する可変長配列クラス。
+ * ヒープ領域を使用しないため、共有メモリに配置できる。
+ * 既存コードにある生配列を最小の変更で置き換えるために、
+ * C++の作法に照らして不適切な演算子を多く定義している。
+ *
+ * @code{.cpp}
+ * using SMruList = StaticVector<SFilePath, 50>;
+ * SMruList mruList{};
+ *
+ * // 以下とおおむね同等。
+ * int nMruFileNum = 0;
+ * SFilePath aMruFileArr[50] {};
+ * @endcode
+ *
+ * @tparam ELEMENT_TYPE 要素型。
+ * @tparam MAX_SIZE バッファの要素数。
+ * @tparam SET_TYPE push_backで追加する型。
+ *
+ * @author kobake
+ * @date 2007.09.23 kobake 作成
+ */
 template <class ELEMENT_TYPE, int MAX_SIZE, class SET_TYPE = const ELEMENT_TYPE&>
-class StaticVector {
+class StaticVector final {
 public:
 	//型
 	using ElementType = ELEMENT_TYPE;
@@ -23,34 +53,40 @@ public:
 private:
 	using ArrayType = std::array<ElementType, MAX_SIZE>;
 
+	using Me = StaticVector<ElementType, MAX_SIZE, SET_TYPE>;
+
 public:
 	static int max_size() noexcept { return MAX_SIZE; }
 
 	StaticVector() = default;
 
-	constexpr explicit StaticVector(std::initializer_list<ElementType> source)
-		: StaticVector(std::span<const ElementType>{ source.begin(), source.size() })
-	{
-	}
-
+	/*!
+	 * @brief データを指定して構築する
+	 */
 	template<std::ranges::sized_range T>
 	constexpr explicit StaticVector(const T& source)
 	{
-		const auto sourceSize = static_cast<size_t>(std::size(source));
+		// 要素数がバッファサイズを越えたら例外を投げる
+		const auto sourceSize = std::size(source);
 		if (static_cast<size_t>(MAX_SIZE) < sourceSize) {
-			throw std::out_of_range("source is out of range.");
+			throw std::out_of_range(std::format("source has too many elements. (elements: {}, allowed: {})", sourceSize, MAX_SIZE));
 		}
 
 		m_nCount = static_cast<int>(sourceSize);
 
-		auto itSource = std::ranges::begin(source);
-		for (int i = 0; i < m_nCount; ++i, ++itSource) {
-			m_aElements[i] = static_cast<ElementType>(*itSource);
-		}
+		std::ranges::copy(source, m_aElements.begin());
+	}
+
+	/*!
+	 * @brief イニシャライザで構築する
+	 */
+	constexpr explicit StaticVector(std::initializer_list<const ElementType> source)
+		: StaticVector(std::span(source.begin(), source.size()))
+	{
 	}
 
 	//属性
-	int size() const noexcept { return m_nCount; }
+	constexpr int size() const noexcept { return m_nCount; }
 
 	constexpr auto begin() noexcept { return m_aElements.begin(); }
 	constexpr auto end() noexcept { return m_aElements.begin() + MAX_SIZE; }
@@ -58,43 +94,94 @@ public:
 	auto begin() const noexcept { return m_aElements.begin(); }
 	auto end() const noexcept { return m_aElements.begin() + m_nCount; }
 
+	constexpr       auto* data()        noexcept { return std::data(m_aElements); }
+	constexpr const auto* data()  const noexcept { return std::data(m_aElements); }
+
+	constexpr explicit		 operator std::span<ElementType, MAX_SIZE>() & noexcept { return std::span<ElementType, MAX_SIZE>{ data(), MAX_SIZE }; }
+	constexpr /* implicit */ operator std::span<ElementType>() & noexcept { return operator std::span<ElementType, MAX_SIZE>(); }
+	constexpr /* implicit */ operator const ElementType*() const & noexcept { return data(); }
+
 	//要素アクセス
-	ElementType& operator[](size_t nIndex) noexcept
+	/*!
+	 * @brief 指定した要素を取得する（読み書き可能。）
+	 *
+	 * @param nIndex [in] 取得する要素のインデックス。
+	 * @returns 指定した要素への参照。（読み書き可能。）
+	 * @throws std::out_of_range インデックスがバッファの要素数を超える場合。
+	 */
+	constexpr ElementType& operator[](size_t nIndex)
 	{
-		assert(nIndex<MAX_SIZE);
-		assert_warning(0 <= m_nCount);
-		assert_warning(0 == m_nCount || nIndex < size_t(m_nCount));
+		// 有効要素数を越えたら例外を投げる
+		if (size_t(m_nCount) <= nIndex) {
+			throw std::out_of_range(std::format("nIndex is out of range. (nIndex: {}, allowed: {})", nIndex, m_nCount - 1));
+		}
+
 		return m_aElements[nIndex];
 	}
+
+	/*!
+	 * @brief 指定した要素を取得する（読み取り専用。）
+	 *
+	 * @param nIndex [in] 取得する要素のインデックス。
+	 * @returns 指定した要素への参照。（読み取り専用。）
+	 * @throws std::out_of_range インデックスがバッファの要素数を超える場合。
+	 */
 	constexpr const ElementType& operator[](size_t nIndex) const
 	{
-		if (MAX_SIZE <= nIndex) {
-			throw std::out_of_range("nIndex is out of range.");
+		// バッファサイズを越えたら例外を投げる
+		if (size_t(MAX_SIZE) <= nIndex) {
+			throw std::out_of_range(std::format("nIndex is out of range. (nIndex: {}, allowed: {})", nIndex, MAX_SIZE - 1));
 		}
+
 		return m_aElements[nIndex];
 	}
 
 	//操作
 	void clear() noexcept { m_nCount=0; }
+
+	/*!
+	 * @brief 配列末尾に要素を追加する
+	 *
+	 * @tparam Args... 要素の構築に必要な引数群。
+	 * @param args [in] 追加するデータ。
+	 * @throws std::out_of_range 有効要素数が既にバッファの要素数に達していた場合。
+	 */
 	template<typename ... Args>
-	void emplace_back(Args ...args)
+	void emplace_back(Args&& ...args)
 	{
-		if (MAX_SIZE <= m_nCount) {
-			throw std::out_of_range("m_nCount is out of range.");
-		}
-		m_aElements[m_nCount++] = ElementType(args...);
+		// 変更前の有効要素数を取得する
+		const auto countOld = m_nCount;
+
+		// 有効要素数を1増やす
+		resize(countOld + 1);
+
+		// 末尾要素に代入する
+		m_aElements[countOld] = ElementType(std::forward<Args>(args)...);
 	}
+
 	void push_back(SET_TYPE e)
 	{
-		if (MAX_SIZE <= m_nCount) {
-			throw std::out_of_range("m_nCount is out of range.");
-		}
-		m_aElements[m_nCount++] = e;
+		// 変更前の有効要素数を取得する
+		const auto countOld = m_nCount;
+
+		// 有効要素数を1増やす
+		resize(countOld + 1);
+
+		// 末尾要素に代入する
+		m_aElements[countOld] = e;
 	}
-	void resize(size_t nNewSize)
+
+	/*!
+	 * @brief 有効要素数を更新する
+	 *
+	 * @param nNewSize [in] 新しい有効要素数。
+	 * @throws std::out_of_range 有効要素数がバッファの要素数を超える場合。
+	 */
+	constexpr void resize(size_t nNewSize)
 	{
-		if (size_t(MAX_SIZE) <= nNewSize) {
-			throw std::out_of_range("nNewSize is out of range.");
+		// バッファサイズを越えたら例外を投げる
+		if (size_t(MAX_SIZE) < nNewSize) {
+			throw std::out_of_range(std::format("nNewSize is out of range. (nNewSize: {}, allowed: {})", nNewSize, MAX_SIZE - 1));
 		}
 		m_nCount = static_cast<int>(nNewSize);
 	}
@@ -103,7 +190,26 @@ public:
 	ElementType* dataPtr() noexcept { return &m_aElements.front();}
 
 	//特殊
+	/*!
+	 * @brief 有効要素数への参照を取得する
+	 *
+	 * カプセル化を無効化する効果がある。
+	 *
+	 * 存在自体が「問題あり」寄り。
+	 *
+	 * CRecent派生クラスで使ってるので削除できない。
+	 */
+	 // TODO: いつか廃止する
 	int& _GetSizeRef(){ return m_nCount; }
+
+	/*!
+	 * @brief の有効要素数を妥当な値に更新する
+	 *
+	 * 有効要素数に不正な値を入れてしまったあとに補正するためのもの。
+	 *
+	 * 存在自体が「問題あり」寄り。
+	 */
+	 // TODO: いつか廃止する
 	void SetSizeLimit(){
 		if( MAX_SIZE < m_nCount ){
 			m_nCount = MAX_SIZE;

--- a/sakura_core/util/StaticType.h
+++ b/sakura_core/util/StaticType.h
@@ -61,8 +61,8 @@ public:
 	/*!
 	 * @brief データを指定して構築する
 	 */
-	template<std::ranges::sized_range T>
-	constexpr explicit StaticVector(const T& source)
+	template<std::ranges::sized_range S>
+	constexpr explicit StaticVector(const S& source)
 	{
 		// 要素数がバッファサイズを越えたら例外を投げる
 		const auto sourceSize = std::size(source);

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -384,8 +384,8 @@ bool CEditView::GetCurrentTextForSearchDlg( CNativeW& cmemCurText, bool bGetHist
 			bGet = true;
 		}
 		if( bGet ){
-			if( 0 < GetDllShareData().m_sSearchKeywords.m_aSearchKeys.size()
-					&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence ){
+			if (!GetDllShareData().m_sSearchKeywords.m_aSearchKeys.empty()
+					&& m_nCurSearchKeySequence < GetDllShareData().m_Common.m_sSearch.m_nSearchKeySequence) {
 				cmemCurText.SetString( GetDllShareData().m_sSearchKeywords.m_aSearchKeys[0] );	// 履歴からとってくる
 				return true; // ""でもtrue
 			}else{

--- a/sakura_core/view/CEditView_Search.cpp
+++ b/sakura_core/view/CEditView_Search.cpp
@@ -267,7 +267,7 @@ bool CEditView::MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide )
 		return false;
 	}
 	m_cTipWnd.m_cKey = cmemCurText;
-	m_cTipWnd.m_cInfo = cmemCurText.GetStringPtr();
+	m_cTipWnd.m_cInfo = cmemCurText;
 	m_cTipWnd.m_nSearchLine = (Int)ptNew.y;
 	m_dwTipTimer = 0;		// 辞書Tipを表示している */
 	m_poTipCurPos = *po;	// 現在のマウスカーソル位置 */
@@ -278,7 +278,7 @@ bool CEditView::MiniMapCursorLineTip( POINT* po, RECT* rc, bool* pbHide )
 void CEditView::GetCurrentTextForSearch( CNativeW& cmemCurText, bool bStripMaxPath /* = true */, bool bTrimSpaceTab /* = false */ )
 {
 	int				i;
-	CNativeW		cmemTopic = L"";
+	CNativeW		cmemTopic{ L"" };
 	const wchar_t*	pLine;
 	CLogicInt		nLineLen;
 	CLogicInt		nIdx;

--- a/sakura_core/window/CMainToolBar.cpp
+++ b/sakura_core/window/CMainToolBar.cpp
@@ -535,7 +535,7 @@ void CMainToolBar::AcceptSharedSearchKey()
 		while (ApiWrap::Combo_GetCount(m_hwndSearchBox) > 0) {
 			ApiWrap::Combo_DeleteString(m_hwndSearchBox, 0);
 		}
-		int nSize = GetDllShareData().m_sSearchKeywords.m_aSearchKeys.size();
+		const auto nSize = static_cast<int>(GetDllShareData().m_sSearchKeywords.m_aSearchKeys.count());
 		for( i = 0; i < nSize; i++ )
 		{
 			ApiWrap::Combo_AddString( m_hwndSearchBox, GetDllShareData().m_sSearchKeywords.m_aSearchKeys[i] );

--- a/src/main/resources/sakura.natvis
+++ b/src/main/resources/sakura.natvis
@@ -13,4 +13,14 @@
     <DisplayString Condition="m_szData[0] == 0">empty</DisplayString>
     <DisplayString Condition="m_szData[0] != 0">{m_szData._Elems,su}</DisplayString>
   </Type>
+  <Type Name="StaticVector&lt;*,*,*&gt;">
+    <DisplayString Condition="m_nCount == 0">empty (0/{$T2,d})</DisplayString>
+    <DisplayString Condition="m_nCount != 0">[{m_aElements._Elems,[m_nCount]na}] ({m_nCount,d}/{$T2,d})</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>m_nCount</Size>
+        <ValuePointer>m_aElements._Elems</ValuePointer>
+      </ArrayItems>
+    </Expand>
+  </Type>
 </AutoVisualizer>

--- a/src/main/resources/sakura.natvis
+++ b/src/main/resources/sakura.natvis
@@ -10,8 +10,15 @@
     </Expand>
   </Type>
   <Type Name="StaticString&lt;*&gt;">
-    <DisplayString Condition="m_szData[0] == 0">empty</DisplayString>
-    <DisplayString Condition="m_szData[0] != 0">{m_szData._Elems,su}</DisplayString>
+    <Intrinsic Name="length" Expression="wcsnlen(m_szData._Elems, $T1 - 1)" />
+    <DisplayString Condition="m_szData[0] == 0">empty (0/{$T1,d})</DisplayString>
+    <DisplayString Condition="m_szData[0] != 0">{m_szData._Elems,su} ({length(),d}/{$T1,d})</DisplayString>
+    <Expand>
+      <ArrayItems>
+        <Size>length() + 1</Size>
+        <ValuePointer>m_szData._Elems</ValuePointer>
+      </ArrayItems>
+    </Expand>
   </Type>
   <Type Name="StaticVector&lt;*,*,*&gt;">
     <DisplayString Condition="m_nCount == 0">empty (0/{$T2,d})</DisplayString>

--- a/src/main/resources/sakura.natvis
+++ b/src/main/resources/sakura.natvis
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?> 
 <AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
   <Type Name="CNativeW">
-    <DisplayString Condition="m_pRawData == 0">empty</DisplayString>
-    <DisplayString Condition="m_pRawData != 0">{m_pRawData,su}</DisplayString>
+    <DisplayString Condition="m_pRawData == 0 || m_nDataBufSize == 0">NULL</DisplayString>
+    <DisplayString Condition="m_nRawLen == 0 || m_pRawData[0] == 0">empty (0,{m_nDataBufSize / 2,d})</DisplayString>
+    <DisplayString Condition="m_pRawData != 0 &amp;&amp; m_pRawData[0] != 0">{m_pRawData,su} ({m_nRawLen / 2,d},{m_nDataBufSize / 2,d})</DisplayString>
     <Expand>
-      <Item Condition="m_pRawData != 0" Name="_Data">m_pRawData,su</Item>
-      <Item Name="_Length">m_nRawLen / 2</Item>
-      <Item Name="_Size">m_nDataBufSize / 2</Item>
+      <ArrayItems Condition="m_pRawData != 0">
+        <Size>(m_nRawLen / 2) + 1</Size>
+        <ValuePointer>(wchar_t*)m_pRawData</ValuePointer>
+      </ArrayItems>
     </Expand>
   </Type>
   <Type Name="StaticString&lt;*&gt;">

--- a/src/test/cpp/tests1/test-cnative.cpp
+++ b/src/test/cpp/tests1/test-cnative.cpp
@@ -24,6 +24,10 @@ TEST(CStringRef, CStringRef)
 	EXPECT_FALSE(v1.IsValid());
 	EXPECT_EQ(L'\0', v1.At(0));
 
+	EXPECT_THAT(v1.length(), Eq(0));
+	EXPECT_THAT(v1.empty(), IsTrue());
+	EXPECT_THAT(v1, StrEq(L""));
+
 	CStringRef v2(sz, cch);
 	EXPECT_STREQ(sz, v2.GetPtr());
 	EXPECT_EQ(cch, v2.GetLength());
@@ -33,6 +37,10 @@ TEST(CStringRef, CStringRef)
 	EXPECT_EQ(L's', v2.At(2));
 	EXPECT_EQ(L't', v2.At(3));
 	EXPECT_EQ(L'\0', v2.At(4));
+
+	EXPECT_THAT(v2.length(), Eq(4));
+	EXPECT_THAT(v2.empty(), IsFalse());
+	EXPECT_THAT(v2, StrEq(L"test"));
 
 	CNativeW cmem(sz, cch);
 	CStringRef v3(cmem);
@@ -936,4 +944,20 @@ TEST(CNativeW, GetCharPrev_Bugs_Preview)
 
 	// 対処方法 関数コメントにある仕様通りに修正する。
 	ASSERT_EQ(&text[2], CNativeW::GetCharPrev(pText, 2, pText));
+}
+
+TEST(CNativeW, length001)
+{
+	CNativeW mem{ L"test" };
+	EXPECT_THAT(mem.length(), Eq(4));
+	EXPECT_THAT(mem.empty(), IsFalse());
+	EXPECT_THAT(mem, StrEq(L"test"));
+}
+
+TEST(CNativeW, length101)
+{
+	CNativeW mem{};
+	EXPECT_THAT(mem.length(), Eq(0));
+	EXPECT_THAT(mem.empty(), IsTrue());
+	EXPECT_THAT(mem, StrEq(L""));
 }

--- a/src/test/cpp/tests1/test-cnative.cpp
+++ b/src/test/cpp/tests1/test-cnative.cpp
@@ -4,11 +4,14 @@
 
 	SPDX-License-Identifier: Zlib
 */
-#include <stdexcept>
 #include "pch.h"
 #include "charset/charcode.h"
 #include "mem/CNativeW.h"
 #include "mem/CNativeA.h"
+
+#include <stdexcept>
+
+using namespace std::literals::string_view_literals;
 
 /*!
 	CStringRefのテスト
@@ -111,22 +114,6 @@ TEST(CNativeW, ConstructWithStringEmpty)
 	ASSERT_STREQ(sz, value.GetStringPtr());
 	EXPECT_EQ(0, value.GetStringLength());
 	EXPECT_LE(0, value.capacity());
-}
-
-/*!
- * @brief コンストラクタ(NULL指定)の仕様
- * @remark バッファは確保されない
- * @remark 文字列長はゼロになる
- */
-TEST(CNativeW, ConstructWithStringNull)
-{
-	CNativeW value(NULL);
-	EXPECT_EQ(0, value.GetStringLength());
-	EXPECT_EQ(NULL, value.GetStringPtr());
-
-	CNativeW value2(NULL);
-	EXPECT_EQ(0, value2.GetStringLength());
-	EXPECT_EQ(NULL, value2.GetStringPtr());
 }
 
 /*!
@@ -251,32 +238,6 @@ TEST(CNativeW, AssignString)
 }
 
 /*!
- * @brief 代入演算子(NULL指定)の仕様
- * @remark バッファを確保している場合は解放される
- * @remark 文字列長はゼロになる
- */
-TEST(CNativeW, AssignStringNullPointer)
-{
-	CNativeW value(L"test");
-	value = nullptr;	// NULLではなくnullptrを使うよう修正
-	EXPECT_EQ(0, value.GetStringLength());
-	EXPECT_EQ(NULL, value.GetStringPtr());
-}
-
-/*!
- * @brief 代入演算子(NULL指定)の仕様
- * @remark バッファを確保している場合は解放される
- * @remark 文字列長はゼロになる
- */
-TEST(CNativeW, AssignStringNullLiteral)
-{
-	CNativeW value(L"test");
-	value = nullptr;	// NULLではなくnullptrを使うよう修正
-	ASSERT_EQ(NULL, value.GetStringPtr());
-	EXPECT_EQ(0, value.GetStringLength());
-}
-
-/*!
  * @brief 加算代入演算子(文字指定)の仕様
  * @remark バッファが確保される
  * @remark 文字列長は演算子呼出前の文字列長+1になる
@@ -311,19 +272,6 @@ TEST(CNativeW, AppendString)
 }
 
 /*!
- * @brief 加算代入演算子(NULL指定)の仕様
- * @remark 加算代入しても内容に変化無し
- */
-TEST(CNativeW, AppendStringNullPointer)
-{
-	CNativeW org(L"orz");
-	CNativeW value(org);
-	value += nullptr;	// NULLではなくnullptrを使うよう修正
-	EXPECT_EQ(value.GetStringLength(), org.GetStringLength());
-	EXPECT_EQ(org, value);
-}
-
-/*!
  * @brief 独自関数AppendStringFの仕様
  * @remark 指定したフォーマットで、引数がフォーマットされる
  * @remark 指定したフォーマットがNULLの場合、例外を投げる
@@ -351,7 +299,7 @@ TEST(CNativeW, AppendStringWithFormatting)
 	ASSERT_EQ(L"いちご25%", value);
 
 	// 未確保状態からの書式化をテストする
-	value = nullptr; //テスト前の初期値(未確保
+	value = CNativeW(); //テスト前の初期値(未確保
 	value.AppendStringF( L"KEY[%03d]", 12 );
 	ASSERT_EQ( L"KEY[012]", value );
 
@@ -366,7 +314,7 @@ TEST(CNativeW, AppendStringWithFormatting)
 	// フォーマット出力長2047字を超える条件をテストする
 	{
 		std::wstring longText( 2048, L'=' );
-		value = nullptr; //テスト前の初期値(未確保
+		value = CNativeW(); //テスト前の初期値(未確保
 		value.AppendStringF( L"%s", longText.c_str() );
 		ASSERT_EQ( longText.c_str(), value );
 	}
@@ -702,7 +650,7 @@ TEST(CNativeW, CompareWithCNativeW)
 }
 
 /*!
- * 文字列ポインタ型との比較のテスト
+ * 文字列型との比較のテスト
  *
  * @remark < 0 自身がメモリ未確保、かつ、比較対象がNULL以外
  * @remark < 0 文字列値が比較対象より小さい
@@ -710,18 +658,19 @@ TEST(CNativeW, CompareWithCNativeW)
  * @remark > 0 自身がメモリ確保済み、かつ、比較対象がNULL
  * @remark > 0 文字列値が比較対象より大きい
  */
-TEST(CNativeW, CompareWithStringPtr)
+TEST(CNativeW, CompareWithString)
 {
 	//互いに値の異なる文字列定数を定義する
-	constexpr const wchar_t* pcN0 = NULL;
-	constexpr const wchar_t szS0[] = L"ab";
-	constexpr const wchar_t szM0[] = L"aac";
-	constexpr const wchar_t szM1[] = L"abc";
-	constexpr const wchar_t szM2[] = L"acc";
-	constexpr const wchar_t szL0[] = L"abcd";
+	constexpr const auto pcN0 = nullptr;
+	constexpr const auto szS0 = L"ab";
+	constexpr const auto szM0 = L"aac";
+	constexpr const auto szM1 = L"abc";
+	constexpr const auto szM2 = L"acc";
+	constexpr const auto szL0 = L"abcd";
 
 	// 定数に対応するCNativeWのインスタンスを用意する
-	CNativeW cN0(pcN0), cM1(szM1);
+	CNativeW cN0;
+	CNativeW cM1(szM1);
 
 	// 比較
 	// ASSERT_GTの判定仕様は v1 > v2
@@ -730,9 +679,9 @@ TEST(CNativeW, CompareWithStringPtr)
 	ASSERT_GT(0, cN0.Compare(szM1));
 	ASSERT_GT(0, cM1.Compare(szM2));
 	ASSERT_GT(0, cM1.Compare(szL0));
-	ASSERT_EQ(0, cN0.Compare(pcN0));
+	ASSERT_EQ(cN0, pcN0);
 	ASSERT_EQ(0, cM1.Compare(szM1));
-	ASSERT_LT(0, cM1.Compare(pcN0));
+	ASSERT_LT(0, cM1.Compare(L""));
 	ASSERT_LT(0, cM1.Compare(szM0));
 	ASSERT_LT(0, cM1.Compare(szS0));
 }
@@ -746,11 +695,11 @@ TEST(CNativeW, globalOperatorAdd)
 {
 	CNativeW v1(L"前半");
 	constexpr const wchar_t v2[] = L"後半";
-	EXPECT_STREQ(L"前半後半", (v1 + v2).GetStringPtr());
+	EXPECT_THAT(v1 + v2, StrEq(L"前半後半"));
 
 	constexpr const wchar_t v3[] = L"前半";
 	CNativeW v4(L"後半");
-	EXPECT_STREQ(L"前半後半", (v3 + v4).GetStringPtr());
+	EXPECT_THAT(v3 + v4, StrEq(L"前半後半"));
 }
 
 /*!

--- a/src/test/cpp/tests1/test-cprofile.cpp
+++ b/src/test/cpp/tests1/test-cprofile.cpp
@@ -54,7 +54,7 @@ TEST(CProfile, ReadProfile_ExpandLineBuffer)
 	cProfile.ReadProfile(iniPath);
 
 	bool value = false;
-	EXPECT_THAT(cProfile.GetProfileData(L"test", L"test", value), IsTrue());
+	EXPECT_THAT(cProfile.IOProfileData(L"test", L"test", value), IsTrue());
 	EXPECT_THAT(value, IsTrue());
 
 	std::filesystem::remove(iniPath, ec);
@@ -92,8 +92,8 @@ TEST(CProfile, ReadProfile_LineTerminatorCr)
 	CDataProfile cProfile;
 	cProfile.ReadProfile(iniPath);
 
-	bool value = false;
-	EXPECT_THAT(cProfile.GetProfileData(L"test", L"test", value), IsTrue());
+	int value = false;
+	EXPECT_THAT(cProfile.IOProfileData(L"test", L"test", value), IsTrue());
 	EXPECT_THAT(value, IsTrue());
 
 	std::filesystem::remove(iniPath, ec);

--- a/src/test/cpp/tests1/test-csearchagent.cpp
+++ b/src/test/cpp/tests1/test-csearchagent.cpp
@@ -21,7 +21,7 @@ template <typename T> void SetLines(CDocLineMgr& m, int seq, T begin, T end)
 {
 	for (auto it = begin; it != end; ++it) {
 		CDocLine* line = m.AddNewLine();
-		line->SetDocLineString(it->data(), it->length());
+		line->SetDocLineString(CNativeW(*it), false);
 		line->m_sMark.m_cModified = seq;
 	}
 }
@@ -41,7 +41,7 @@ COpeLineData MakeOpeLineData(std::initializer_list<RawLineData> lines)
 	COpeLineData data;
 	for (RawLineData rawLine : lines) {
 		CLineData line;
-		line.cmemLine = rawLine.line;
+		line.cmemLine = std::wstring_view(rawLine.line);
 		line.nSeq = rawLine.seq;
 		data.push_back(line);
 	}

--- a/src/test/cpp/tests1/test-csharedata.cpp
+++ b/src/test/cpp/tests1/test-csharedata.cpp
@@ -1682,22 +1682,22 @@ MATCHER_P4(IsInitializedShareData, pszProfileName, isMultiUserSettings, userRoot
 
 	EXPECT_THAT(shareData.m_nLockCount, 0);
 
-	EXPECT_THAT(shareData.m_sSearchKeywords.m_aSearchKeys.size(), 0);
-	EXPECT_THAT(shareData.m_sSearchKeywords.m_aReplaceKeys.size(), 0);
-	EXPECT_THAT(shareData.m_sSearchKeywords.m_aGrepFiles.size(), 1);
+	EXPECT_THAT(shareData.m_sSearchKeywords.m_aSearchKeys.count(), 0);
+	EXPECT_THAT(shareData.m_sSearchKeywords.m_aReplaceKeys.count(), 0);
+	EXPECT_THAT(shareData.m_sSearchKeywords.m_aGrepFiles.count(), 1);
 	EXPECT_THAT(shareData.m_sSearchKeywords.m_aGrepFiles[0], StrEq(L"*.*"));
-	EXPECT_THAT(shareData.m_sSearchKeywords.m_aGrepFolders.size(), 0);
+	EXPECT_THAT(shareData.m_sSearchKeywords.m_aGrepFolders.count(), 0);
 
 	EXPECT_THAT(shareData.m_sTagJump.m_TagJumpNum, 0);
 	EXPECT_THAT(shareData.m_sTagJump.m_TagJumpTop, 0);
-	EXPECT_THAT(shareData.m_sTagJump.m_aTagJumpKeywords.size(), 0);
+	EXPECT_THAT(shareData.m_sTagJump.m_aTagJumpKeywords.count(), 0);
 	EXPECT_THAT(shareData.m_sTagJump.m_bTagJumpICase, IsFalse());
 	EXPECT_THAT(shareData.m_sTagJump.m_bTagJumpPartialMatch, IsFalse());
 
-	EXPECT_THAT(shareData.m_sHistory.m_aExceptMRU.size(), 0);
+	EXPECT_THAT(shareData.m_sHistory.m_aExceptMRU.count(), 0);
 	EXPECT_THAT(shareData.m_sHistory.m_szIMPORTFOLDER, StrEq(iniFolder));
-	EXPECT_THAT(shareData.m_sHistory.m_aCommands.size(), 0);
-	EXPECT_THAT(shareData.m_sHistory.m_aCurDirs.size(), 0);
+	EXPECT_THAT(shareData.m_sHistory.m_aCommands.count(), 0);
+	EXPECT_THAT(shareData.m_sHistory.m_aCurDirs.count(), 0);
 
 	EXPECT_THAT(shareData.m_nExecFlgOpt, 1);
 	EXPECT_THAT(shareData.m_nDiffFlgOpt, 0);

--- a/src/test/cpp/tests1/test-statictype.cpp
+++ b/src/test/cpp/tests1/test-statictype.cpp
@@ -11,13 +11,15 @@ namespace basis {
 
 static_assert([] {
 	const StaticVector<size_t, 3> vec{ 10u, 20u, 30u };
-	return vec.size() == 3 && vec[0] == 10u && vec[1] == 20u && vec[2] == 30u;
+	return vec.size() == 3 && vec.count() == 3 && !vec.empty() && vec[0] == 10u && vec[1] == 20u && vec[2] == 30u;
 }());
+
+static_assert(StaticVector<size_t, 3>{}.empty());
 
 static_assert([] {
 	const std::vector<size_t> source{ 10u, 20u, 30u };
 	const StaticVector<size_t, 3> vec(source);
-	return vec.size() == 3 && vec[0] == 10u && vec[1] == 20u && vec[2] == 30u;
+	return vec.size() == 3 && vec.count() == 3 && vec[0] == 10u && vec[1] == 20u && vec[2] == 30u;
 }());
 
 /*!
@@ -27,7 +29,9 @@ TEST(StaticVector, test001)
 {
 	StaticVector<size_t, 3> vec{ 10u, 20u, 30u };
 
-	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec.size(), Eq(3u));
+	EXPECT_THAT(vec.count(), Eq(3u));
+	EXPECT_THAT(vec.empty(), IsFalse());
 	EXPECT_THAT(vec[0], Eq(10u));
 	EXPECT_THAT(vec[1], Eq(20u));
 	EXPECT_THAT(vec[2], Eq(30u));
@@ -45,28 +49,6 @@ TEST(StaticVector, test001)
 	// 追加できないので、サイズをカウントアップしてはいけない
 	EXPECT_THAT(vec.size(), Eq(3));
 
-	// 範囲外アクセス
-	try {
-		auto cv = vec;
-		cv[3];
-
-		FAIL() << "Expected std::out_of_range to be thrown";
-	}
-	catch (const std::out_of_range& e) {
-		EXPECT_THAT(e.what(), StrEq("nIndex is out of range. (nIndex: 3, allowed: 2)"));
-	}
-
-	// 範囲外アクセス
-	try {
-		const auto& cv = vec;
-		cv[3];
-
-		FAIL() << "Expected std::out_of_range to be thrown";
-	}
-	catch (const std::out_of_range& e) {
-		EXPECT_THAT(e.what(), StrEq("nIndex is out of range. (nIndex: 3, allowed: 2)"));
-	}
-
 	auto* ptr = vec.dataPtr();
 	ptr[0] = 10u;
 	ptr[1] = 20u;
@@ -75,45 +57,46 @@ TEST(StaticVector, test001)
 	EXPECT_THAT(vec[1], Eq(20u));
 
 	EXPECT_THROW({ vec.resize(4); }, std::out_of_range);
-	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec.count(), Eq(3u));
 
 	vec.resize(2);
-	EXPECT_THAT(vec.size(), Eq(2));
+	EXPECT_THAT(vec.count(), Eq(2u));
 
 	vec.resize(1);
-	EXPECT_THAT(vec.size(), Eq(1));
+	EXPECT_THAT(vec.count(), Eq(1u));
 	EXPECT_THAT(vec[0], Eq(10u));
 
 	vec.push_back(20u);
 	vec.emplace_back(30u);
 
-	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec.count(), Eq(3));
 	EXPECT_THAT(vec[1], Eq(20u));
 	EXPECT_THAT(vec[2], Eq(30u));
 	EXPECT_THAT(std::distance(vec.begin(), vec.end()), Eq(3));
 
 	vec.clear();
-	EXPECT_THAT(vec.size(), Eq(0));
+	EXPECT_THAT(vec.count(), Eq(0u));
+	EXPECT_THAT(vec.empty(), IsTrue());
 	EXPECT_THAT(std::distance(vec.begin(), vec.end()), Eq(3));
 
 	auto& sizeRef = vec._GetSizeRef();
 
 	sizeRef = 2;
 	vec.SetSizeLimit();
-	EXPECT_THAT(vec.size(), Eq(2));
+	EXPECT_THAT(vec.count(), Eq(2u));
 
 	sizeRef = 99;
 	vec.SetSizeLimit();
-	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec.count(), Eq(3u));
 
 	sizeRef = -1;
 	vec.SetSizeLimit();
-	EXPECT_THAT(vec.size(), Eq(0));
+	EXPECT_THAT(vec.count(), Eq(0u));
 
 	// 引数足りない
 	vec = StaticVector<size_t, 3>{ 10u, 20u };
 
-	EXPECT_THAT(vec.size(), Eq(2));
+	EXPECT_THAT(vec.count(), Eq(2u));
 	EXPECT_THAT(vec[0], Eq(10u));
 	EXPECT_THAT(vec[1], Eq(20u));
 	EXPECT_THAT(std::distance(vec.begin(), vec.end()), Eq(3));
@@ -121,22 +104,12 @@ TEST(StaticVector, test001)
 	const auto& cv = vec;
 	EXPECT_THAT(std::distance(cv.begin(), cv.end()), Eq(2));
 
-	// 引数多過ぎ
-	try {
-		vec = StaticVector<size_t, 3>{ 10u, 20u, 30u, 40u };
-
-		FAIL() << "Expected std::out_of_range to be thrown";
-	}
-	catch (const std::out_of_range& e) {
-		EXPECT_THAT(e.what(), StrEq("source has too many elements. (elements: 4, allowed: 3)"));
-	}
-
 	// 長さ3の配列を用意する
 	const std::array<size_t, 3> source{ 10u, 20u, 30u };
 
 	vec = StaticVector<size_t, 3>(source);
 
-	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec.count(), Eq(3u));
 	EXPECT_THAT(vec[0], Eq(10u));
 	EXPECT_THAT(vec[1], Eq(20u));
 	EXPECT_THAT(vec[2], Eq(30u));
@@ -145,13 +118,42 @@ TEST(StaticVector, test001)
 	const std::vector<size_t> vectorSource{ 10u, 20u, 30u };
 	vec = StaticVector<size_t, 3>(vectorSource);
 
-	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec.count(), Eq(3u));
 	EXPECT_THAT(vec[0], Eq(10u));
 	EXPECT_THAT(vec[1], Eq(20u));
 	EXPECT_THAT(vec[2], Eq(30u));
 
 	const std::vector<size_t> tooLargeVector{ 10u, 20u, 30u, 40u };
 	EXPECT_THROW((StaticVector<size_t, 3>(tooLargeVector)), std::out_of_range);
+}
+
+TEST(StaticVector, test101)
+{
+	EXPECT_THAT(([] {
+		// バッファサイズより引数が多いと例外。
+		StaticVector<size_t, 3> vec{ 10u, 20u, 30u, 40u }; }),
+		ThrowsMessage<std::out_of_range>(Eq("source has too many elements. (elements: 4, allowed: 3)"))
+	);
+}
+
+TEST(StaticVector, test102)
+{
+	EXPECT_THAT(([] {
+		// 有効要素数より大きなインデックスを指定すると例外。
+		StaticVector<size_t, 3> vec{ 10u, 20u };
+		vec[2] = 0; }),
+		ThrowsMessage<std::out_of_range>(Eq("nIndex is out of range. (nIndex: 2, allowed: 1)"))
+	);
+}
+
+TEST(StaticVector, test103)
+{
+	EXPECT_THAT(([] {
+		// バッファサイズより大きなインデックスを指定すると例外。
+		const StaticVector<size_t, 3> vec{ 10u, 20u };
+		(void) vec[3]; }),
+		ThrowsMessage<std::out_of_range>(Eq("nIndex is out of range. (nIndex: 3, allowed: 2)"))
+	);
 }
 
 /*!

--- a/src/test/cpp/tests1/test-statictype.cpp
+++ b/src/test/cpp/tests1/test-statictype.cpp
@@ -9,6 +9,17 @@
 
 namespace basis {
 
+static_assert([] {
+	const StaticVector<size_t, 3> vec{ 10u, 20u, 30u };
+	return vec.size() == 3 && vec[0] == 10u && vec[1] == 20u && vec[2] == 30u;
+}());
+
+static_assert([] {
+	const std::vector<size_t> source{ 10u, 20u, 30u };
+	const StaticVector<size_t, 3> vec(source);
+	return vec.size() == 3 && vec[0] == 10u && vec[1] == 20u && vec[2] == 30u;
+}());
+
 /*!
 	@brief StaticVectorのテスト
  */
@@ -36,13 +47,24 @@ TEST(StaticVector, test001)
 
 	// 範囲外アクセス
 	try {
+		auto cv = vec;
+		cv[3];
+
+		FAIL() << "Expected std::out_of_range to be thrown";
+	}
+	catch (const std::out_of_range& e) {
+		EXPECT_THAT(e.what(), StrEq("nIndex is out of range. (nIndex: 3, allowed: 2)"));
+	}
+
+	// 範囲外アクセス
+	try {
 		const auto& cv = vec;
 		cv[3];
 
 		FAIL() << "Expected std::out_of_range to be thrown";
 	}
 	catch (const std::out_of_range& e) {
-		EXPECT_STREQ(e.what(), "nIndex is out of range.");
+		EXPECT_THAT(e.what(), StrEq("nIndex is out of range. (nIndex: 3, allowed: 2)"));
 	}
 
 	auto* ptr = vec.dataPtr();
@@ -106,7 +128,7 @@ TEST(StaticVector, test001)
 		FAIL() << "Expected std::out_of_range to be thrown";
 	}
 	catch (const std::out_of_range& e) {
-		EXPECT_STREQ(e.what(), "source is out of range.");
+		EXPECT_THAT(e.what(), StrEq("source has too many elements. (elements: 4, allowed: 3)"));
 	}
 
 	// 長さ3の配列を用意する
@@ -119,6 +141,17 @@ TEST(StaticVector, test001)
 	EXPECT_THAT(vec[1], Eq(20u));
 	EXPECT_THAT(vec[2], Eq(30u));
 	EXPECT_THAT(std::distance(vec.begin(), vec.end()), Eq(3));
+
+	const std::vector<size_t> vectorSource{ 10u, 20u, 30u };
+	vec = StaticVector<size_t, 3>(vectorSource);
+
+	EXPECT_THAT(vec.size(), Eq(3));
+	EXPECT_THAT(vec[0], Eq(10u));
+	EXPECT_THAT(vec[1], Eq(20u));
+	EXPECT_THAT(vec[2], Eq(30u));
+
+	const std::vector<size_t> tooLargeVector{ 10u, 20u, 30u, 40u };
+	EXPECT_THROW((StaticVector<size_t, 3>(tooLargeVector)), std::out_of_range);
 }
 
 /*!

--- a/src/test/resources/pch.h
+++ b/src/test/resources/pch.h
@@ -33,6 +33,7 @@ using ::testing::StrCaseEq;
 using ::testing::StrCaseNe;
 using ::testing::StrEq;
 using ::testing::StrNe;
+using ::testing::ThrowsMessage;
 
 //! googletestに機能IDを出力させる
 void PrintTo(EFunctionCode eFuncCode, std::ostream* os);


### PR DESCRIPTION
<!-- これはコメントです。ブラウザで表示されません。 -->
<!-- Preview のシートで見た目のチェックができます。 -->

# <!-- 必須 --> PR対象

<!-- PR対象を以下のテンプレートより選択してください。 -->
<!-- 該当するものがなければ追加してください。 -->

- アプリ(サクラエディタ本体)
- テストコード

## <!-- 必須 --> カテゴリ

<!-- 編集 必須 -->
<!-- 以下のテンプレは自由に編集してください。 -->

- 改善

## <!-- 必須 --> PR の背景

<!-- PR前に作成したissue番号を記載してください。 -->
<!-- issueを作成していない場合、背景の説明で代替しても良いです。 -->
- 先行 issue はとくに作成していません。

## <!-- 必須 --> 仕様・動作説明

<!-- ふるまいを変えない変更の場合は省略可。 -->
- 独自の可変長配列クラス StaticVector を整備します。
- 独自の固定長文字列バッファクラス StaticString を整備します。
- 独自の可変長文字列バッファクラス CNativeW を整備します。

「生配列の代わりに使えるクラスを整備する」の目的で始めた整備でしたが、
CNativeWも合わせて整備するのが妥当と思われたため一緒に含めることにしました。

最大の変更点はNULLの扱いです。

変更前） 文字列は LPCWSTR で受け取る。
変更後） 文字列は std::wstring_view で受け取る。

LPCWSTR はwchar_tポインタなので、NULL値になり得ます。
std::wstring_view は文字列参照なので、NULL値になりません。

旧来の実装では NULL を有効な無効値として扱うために色々苦労していました。
思い切って 「NULL値は無効」 に倒してしまうことで整理しやすくします。

```C++
LPCWSTR pszText = nullptr;
SFilePath szFile{};
szFile = pszText; // ←従来なら有効だったコード。
```

今後は無効で、やったらクラッシュします。

「いい悪い」の判断は不可能と思うので、
本件も勝手にやります。

## <!-- わかる範囲で --> PR の影響範囲

<!-- 影響範囲を記載してください。 -->

## <!-- 必須 --> テスト内容

<!-- PR内容の妥当性をどのように確認したかについて記載してください。 -->

<!-- レビュアーが確認する再現手順があれば記載してください。 -->

## <!-- なければ省略可 --> 関連 issue, PR

<!-- 関連する issue, PR の情報を記載してください。 -->
<!-- #xxx と書くと チケット xxx に対して自動的にリンクが張られます。 -->
<!-- 参考: https://help.github.com/en/articles/closing-issues-using-keywords-->
<!-- issue, PR の URL をそのまま貼り付けても OK -->


## <!-- なければ省略可 --> 参考資料

<!-- 参考になる資料の URL 等あればここに記載御願いします -->
<!-- 説明に必要なスクリーンショットがあれば貼り付けお願いします。-->
<!-- 画像ファイルをこの欄にドラッグ＆ドロップすれば画像が貼り付けられます -->
