### PR TITLE
マクロの文字コード変換に失敗した場合にエラーメッセージを表示する

### DIFF
--- a/sakura_core/cmd/CViewCommander.cpp
+++ b/sakura_core/cmd/CViewCommander.cpp
@@ -137,14 +137,29 @@ BOOL CViewCommander::HandleCommand(
 	//	From Here Sep. 29, 2001 genta マクロの実行機能追加
 	if( F_USERMACRO_0 <= nCommand && nCommand < F_USERMACRO_0 + (int)MAX_CUSTMACRO ){
 		//@@@ 2002.2.2 YAZAKI マクロをCSMacroMgrに統一（インターフェースの変更）
-		if( !m_pcSMacroMgr->Exec( nCommand - F_USERMACRO_0, G_AppInstance(), m_pCommanderView,
-			nCommandFrom & FA_NONRECORD )){
-			InfoMessage(
-				this->m_pCommanderView->m_hwndParent,
-				LS(STR_ERR_MACRO1),
-				nCommand - F_USERMACRO_0,
-				m_pcSMacroMgr->GetFile( nCommand - F_USERMACRO_0 )
-			);
+		const auto eMacroResult = m_pcSMacroMgr->Exec(
+			nCommand - F_USERMACRO_0,
+			G_AppInstance(),
+			m_pCommanderView,
+			nCommandFrom & FA_NONRECORD
+		);
+		if( eMacroResult != EMacroResult::Success ){
+			if( eMacroResult == EMacroResult::EncodingError ){
+				//	マクロファイルの文字コード変換エラー
+				ErrorMessage(
+					this->m_pCommanderView->m_hwndParent,
+					LS(STR_ERR_MACRO_ENCODING),
+					m_pcSMacroMgr->GetFile( nCommand - F_USERMACRO_0 )
+				);
+			}
+			else {
+				InfoMessage(
+					this->m_pCommanderView->m_hwndParent,
+					LS(STR_ERR_MACRO1),
+					nCommand - F_USERMACRO_0,
+					m_pcSMacroMgr->GetFile( nCommand - F_USERMACRO_0 )
+				);
+			}
 		}
 		return TRUE;
 	}

--- a/sakura_core/cmd/CViewCommander_Macro.cpp
+++ b/sakura_core/cmd/CViewCommander_Macro.cpp
@@ -179,14 +179,18 @@ void CViewCommander::Command_EXECKEYMACRO( void )
 	if ( GetDllShareData().m_Common.m_sMacro.m_szKeyMacroFileName[0] ){
 		//	ファイルが保存されていたら
 		//@@@ 2002.2.2 YAZAKI マクロをCSMacroMgrに統一
-		BOOL bLoadResult = m_pcSMacroMgr->Load(
+		const auto eLoadResult = m_pcSMacroMgr->Load(
 			STAND_KEYMACRO,
 			G_AppInstance(),
 			GetDllShareData().m_Common.m_sMacro.m_szKeyMacroFileName,
 			nullptr
 		);
-		if ( !bLoadResult ){
-			ErrorMessage( m_pCommanderView->GetHwnd(), LS(STR_ERR_CEDITVIEW_CMD28), GetDllShareData().m_Common.m_sMacro.m_szKeyMacroFileName );
+		if ( eLoadResult != EMacroResult::Success ){
+			ErrorMessage(
+				m_pCommanderView->GetHwnd(),
+				eLoadResult == EMacroResult::EncodingError ? LS(STR_ERR_MACRO_ENCODING) : LS(STR_ERR_CEDITVIEW_CMD28),
+				GetDllShareData().m_Common.m_sMacro.m_szKeyMacroFileName
+			);
 		}
 		else {
 			//	2007.07.20 genta : flagsオプション追加
@@ -251,14 +255,18 @@ void CViewCommander::Command_EXECEXTMACRO( const WCHAR* pszPath, const WCHAR* ps
 	//古い一時マクロの退避
 	CMacroManagerBase* oldMacro = m_pcSMacroMgr->SetTempMacro( nullptr );
 
-	if (const auto bLoadResult = m_pcSMacroMgr->Load(
+	if (const auto eLoadResult = m_pcSMacroMgr->Load(
 		TEMP_KEYMACRO,
 		G_AppInstance(),
 		pszPath,
 		pszType
 	);
-		!bLoadResult) {
-		ErrorMessage( m_pCommanderView->GetHwnd(), LS(STR_ERR_MACROERR1), pszPath );
+		eLoadResult != EMacroResult::Success) {
+		ErrorMessage(
+			m_pCommanderView->GetHwnd(),
+			eLoadResult == EMacroResult::EncodingError ? LS(STR_ERR_MACRO_ENCODING) : LS(STR_ERR_MACROERR1),
+			pszPath
+		);
 	}
 	else {
 		m_pcSMacroMgr->Exec( TEMP_KEYMACRO, G_AppInstance(), m_pCommanderView, FA_NONRECORD | FA_FROMMACRO );

--- a/sakura_core/io/CTextStream.cpp
+++ b/sakura_core/io/CTextStream.cpp
@@ -15,6 +15,8 @@
 #include "util/tchar_convert.h"
 #include "util/module.h"
 
+#include <stdexcept>
+
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
 //                     CTextInputStream                        //
 // -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- //
@@ -91,7 +93,13 @@ void CTextInputStream::ReadLineW(std::wstring& line)
 	const auto codePage = m_bIsUtf8 ? CP_UTF8 : CP_SJIS;	// UTF-8ならCP_UTF8、そうでなければShift_JIS(CP932)とする
 
 	// 変換を実行する
-	cxx::MultiByteToWideChar(codePage, std::string_view{ m_Buffer.begin(), it }, line);
+	try {
+		cxx::MultiByteToWideChar(codePage, std::string_view{ m_Buffer.begin(), it }, line);
+	}
+	catch (const std::invalid_argument&) {
+		// 呼び出し元が文字コード変換の失敗を他の不正引数と区別できるようにする
+		throw CError_TextEncoding();
+	}
 }
 
 /*!

--- a/sakura_core/io/CTextStream.h
+++ b/sakura_core/io/CTextStream.h
@@ -23,6 +23,9 @@
 
 class CCodeBase;
 
+//! テキスト入力時の文字コード変換エラー
+class CError_TextEncoding {};
+
 //テキスト入力ストリーム (UTF-8, SJIS)
 class CTextInputStream : public CStream{
 public:

--- a/sakura_core/macro/CSMacroMgr.cpp
+++ b/sakura_core/macro/CSMacroMgr.cpp
@@ -30,6 +30,7 @@
 #include "macro/CPythonMacroManager.h"
 #include "macro/CMacroFactory.h"
 #include "env/CShareData.h"
+#include "io/CTextStream.h"
 #include "view/CEditView.h"
 #include "debug/CRunningTimer.h"
 
@@ -591,7 +592,7 @@ int CSMacroMgr::Append(
 
 	@date 2007.07.16 genta flags追加
 */
-BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int flags )
+EMacroResult CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int flags )
 {
 	if( idx == STAND_KEYMACRO ){
 		//	Jun. 16, 2002 genta
@@ -602,10 +603,10 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 			int prevmacro = SetCurrentIdx( idx );
 			m_pKeyMacro->ExecKeyMacro2( pcEditView, flags );
 			SetCurrentIdx( prevmacro );
-			return TRUE;
+			return EMacroResult::Success;
 		}
 		else {
-			return FALSE;
+			return EMacroResult::Failure;
 		}
 	}
 	if( idx == TEMP_KEYMACRO ){		// 一時マクロ
@@ -613,14 +614,14 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 			int prevmacro = SetCurrentIdx( idx );
 			m_pTempMacro->ExecKeyMacro2( pcEditView, flags );
 			SetCurrentIdx( prevmacro );
-			return TRUE;
+			return EMacroResult::Success;
 		}
 		else {
-			return FALSE;
+			return EMacroResult::Failure;
 		}
 	}
 	if( idx < 0 || MAX_CUSTMACRO <= idx )	//	範囲チェック
-		return FALSE;
+		return EMacroResult::Failure;
 
 	/* 読み込み前か、毎回読み込む設定の場合は、ファイルを読み込みなおす */
 	//	Apr. 29, 2002 genta
@@ -631,11 +632,11 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 		WCHAR ptr[_MAX_PATH * 2];
 		int n = CShareData::getInstance()->GetMacroFilename( idx, ptr, int(std::size(ptr)) );
 		if ( n <= 0 ){
-			return FALSE;
+			return EMacroResult::Failure;
 		}
 
-		if( !Load( idx, hInstance, ptr, nullptr ) )
-			return FALSE;
+		if( const auto eLoadResult = Load( idx, hInstance, ptr, nullptr ); eLoadResult != EMacroResult::Success )
+			return eLoadResult;
 	}
 
 	//	Sep. 15, 2005 FILE
@@ -645,7 +646,7 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 	m_cSavedKeyMacro[idx]->ExecKeyMacro2(pcEditView, flags);
 	SetCurrentIdx( prevmacro );
 
-	return TRUE;
+	return EMacroResult::Success;
 }
 
 /*! キーボードマクロの読み込み
@@ -659,7 +660,7 @@ BOOL CSMacroMgr::Exec( int idx , HINSTANCE hInstance, CEditView* pcEditView, int
 
 	@author Norio Nakatani, YAZAKI, genta
 */
-BOOL CSMacroMgr::Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const WCHAR* pszType )
+EMacroResult CSMacroMgr::Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const WCHAR* pszType )
 {
 	CMacroManagerBase** ppMacro = Idx2Ptr( idx );
 
@@ -693,28 +694,32 @@ BOOL CSMacroMgr::Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const
 	m_sMacroPath.clear();
 	*ppMacro = CMacroFactory::getInstance()->Create(ext);
 	if( *ppMacro == nullptr )
-		return FALSE;
-	BOOL bRet;
-	if( pszType == nullptr ){
-		bRet = (*ppMacro)->LoadKeyMacro(hInstance, pszPath);
-		if (idx == STAND_KEYMACRO || idx == TEMP_KEYMACRO) {
-			m_sMacroPath = pszPath;
+		return EMacroResult::Failure;
+	EMacroResult eResult = EMacroResult::Failure;
+	try{
+		if( pszType == nullptr ){
+			eResult = (*ppMacro)->LoadKeyMacro(hInstance, pszPath) ? EMacroResult::Success : EMacroResult::Failure;
+			if (idx == STAND_KEYMACRO || idx == TEMP_KEYMACRO) {
+				m_sMacroPath = pszPath;
+			}
+		}else{
+			eResult = (*ppMacro)->LoadKeyMacroStr(hInstance, pszPath) ? EMacroResult::Success : EMacroResult::Failure;
 		}
-	}else{
-		bRet = (*ppMacro)->LoadKeyMacroStr(hInstance, pszPath);
+	}
+	catch( const CError_TextEncoding& ){
+		//	マクロファイルの文字コード変換エラー
+		//	例外はここで止め、読み込み失敗時の共通処理で生成途中のオブジェクトを解放する
+		eResult = EMacroResult::EncodingError;
 	}
 
 	//	From Here Jun. 16, 2002 genta
 	//	読み込みエラー時はインスタンス削除
-	if( bRet ){
-		return TRUE;
-	}
-	else {
+	if( eResult != EMacroResult::Success ){
 		delete *ppMacro;
 		*ppMacro = nullptr;
 	}
 	//	To Here Jun. 16, 2002 genta
-	return FALSE;
+	return eResult;
 }
 
 /** マクロオブジェクトをすべて破棄する(キーボードマクロ以外)

--- a/sakura_core/macro/CSMacroMgr.h
+++ b/sakura_core/macro/CSMacroMgr.h
@@ -33,6 +33,13 @@ const int STAND_KEYMACRO	= -1;	//!< 標準マクロ(キーマクロ)
 const int TEMP_KEYMACRO		= -2;	//!< 一時マクロ(名前を指定してマクロ実行)
 const int INVALID_MACRO_IDX	= -3;	//!< 無効なマクロのインデックス番号 @date Sep. 15, 2005 FILE
 
+//! マクロの読み込み・実行結果
+enum class EMacroResult {
+	Success,
+	Failure,
+	EncodingError,
+};
+
 struct MacroFuncInfoEx
 {
 	int			m_nArgMinSize;
@@ -83,7 +90,7 @@ public:
 	void ClearAll( void );	/* キーマクロのバッファをクリアする */
 
 	//! キーボードマクロの実行
-	BOOL Exec( int idx, HINSTANCE hInstance, CEditView* pcEditView, int flags );
+	EMacroResult Exec( int idx, HINSTANCE hInstance, CEditView* pcEditView, int flags );
 	
 	//!	実行可能か？CShareDataに問い合わせ
 	bool IsEnabled(int idx) const {
@@ -118,7 +125,8 @@ public:
 	}
 
 	/*! キーボードマクロの読み込み */
-	BOOL Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const WCHAR* pszType );
+	EMacroResult Load( int idx, HINSTANCE hInstance, const WCHAR* pszPath, const WCHAR* pszType );
+
 	BOOL Save( int idx, HINSTANCE hInstance, const WCHAR* pszPath );
 	void UnloadAll(void);
 

--- a/sakura_core/sakura_rc.rc
+++ b/sakura_core/sakura_rc.rc
@@ -4080,6 +4080,7 @@ BEGIN
     IDS_EOLTYPENAME_4 "NEL"
     IDS_EOLTYPENAME_5 "LS"
     IDS_EOLTYPENAME_6 "PS"
+    STR_ERR_MACRO_ENCODING  "文字コードの変換に失敗しました。\nBOM付きUTF-8またはShift_JIS等で保存されているか確認してください。\n\n%s"
     F_WINMAXIMIZE     "最大化"
     F_WINMINIMIZE     "最小化"
     F_WINRESTORE      "元に戻す"

--- a/sakura_lang/sakura_rc_en-US.rc
+++ b/sakura_lang/sakura_rc_en-US.rc
@@ -4150,6 +4150,7 @@ BEGIN
     IDS_EOLTYPENAME_4 "NEL"
     IDS_EOLTYPENAME_5 "LS"
     IDS_EOLTYPENAME_6 "PS"
+    STR_ERR_MACRO_ENCODING  "Failed to convert character encoding.\nCheck that the file is saved as UTF-8 with BOM or Shift_JIS.\n\n%s"
 END
 
 #endif    // 英語 (米国) resources

--- a/sakura_lang/sakura_rc_zh-CN.rc
+++ b/sakura_lang/sakura_rc_zh-CN.rc
@@ -4047,6 +4047,7 @@ BEGIN
     IDS_EOLTYPENAME_4 "NEL"
     IDS_EOLTYPENAME_5 "LS"
     IDS_EOLTYPENAME_6 "PS"
+    STR_ERR_MACRO_ENCODING  "字符编码转换失败。\n请确认文件是否以带BOM的UTF-8或Shift_JIS等编码保存。\n\n%s"
 END
 
 #endif    // 中国語 (簡体字、中国) resources

--- a/src/main/resources/sakura_rc.h
+++ b/src/main/resources/sakura_rc.h
@@ -1850,13 +1850,14 @@
 #define IDS_EOLTYPENAME_4               35054
 #define IDS_EOLTYPENAME_5               35055
 #define IDS_EOLTYPENAME_6               35056
+#define STR_ERR_MACRO_ENCODING          35057
 #define IDC_STATIC                      -1
 
 // Next default values for new objects
 // 
 #ifdef APSTUDIO_INVOKED
 #ifndef APSTUDIO_READONLY_SYMBOLS
-#define _APS_NEXT_RESOURCE_VALUE        35057
+#define _APS_NEXT_RESOURCE_VALUE        35058
 #define _APS_NEXT_COMMAND_VALUE         101
 #define _APS_NEXT_CONTROL_VALUE         1741
 #define _APS_NEXT_SYMED_VALUE           10000

--- a/src/test/cpp/tests1/macro/test-macro.cpp
+++ b/src/test/cpp/tests1/macro/test-macro.cpp
@@ -11,6 +11,7 @@
 #include "macro/CPPAMacroMgr.h"
 #include "macro/CPythonMacroManager.h"
 #include "macro/CWSHManager.h"
+#include "io/CTextStream.h"
 
 #include "window/EditorTestSuite.hpp"
 
@@ -409,6 +410,63 @@ TEST_F(MacroMgrTest, CWSHMacroManager001)
 	EXPECT_THAT(mgr->ExecKeyMacro(&pcEditWnd->GetActiveView(), 0), IsTrue());
 
 	mgr = nullptr;
+
+	CMacroFactory::getInstance()->Unregister(CWSHMacroManager::Creator);
+}
+
+/*!
+ * BOMなしUTF-8で保存されたマクロファイルの読み込み
+ *
+ * BOMのないファイルはShift_JISとして読み込まれる。
+ * UTF-8の日本語の行末バイトがShift_JISの先頭バイトになると不完全なシーケンスとなり、
+ * CTextInputStream::ReadLineW は CError_TextEncoding を投げる。
+ * CSMacroMgr::Load はこれを捕まえて文字コード変換エラーを返す。
+ */
+TEST_F(MacroMgrTest, CWSHMacroManagerUtf8NoBom001)
+{
+	CWSHMacroManager::declare();
+
+	const HINSTANCE unusedArg1 = nullptr;
+	const auto path = GetTempFilePathWithExt(L"tes", L"js");
+
+	// "// 日本語コメント" + "Editor.InsText("ASCII");"
+	// 行末の「ト」(E3 83 88) の 0x88 がShift_JISの先頭バイトとして孤立する
+	constexpr auto macroBody =
+		"// \xE6\x97\xA5\xE6\x9C\xAC\xE8\xAA\x9E\xE3\x82\xB3\xE3\x83\xA1\xE3\x83\xB3\xE3\x83\x88\r\n"
+		"Editor.InsText(\"ASCII\");\r\n";
+
+	// BOMなしUTF-8で書き込む
+	{
+		std::ofstream fs(path, std::ios::binary);
+		fs << macroBody;
+	}
+
+	// エンジン単体では例外が上がる
+	auto mgr = std::unique_ptr<CMacroManagerBase>(CMacroFactory::getInstance()->Create(L"js"));
+	EXPECT_THROW(mgr->LoadKeyMacro(unusedArg1, path.c_str()), CError_TextEncoding);
+	mgr = nullptr;
+
+	// CSMacroMgr::Load は例外を止めて文字コード変換エラーを返す
+	EXPECT_THAT(pcSMacroMgr->Load(TEMP_KEYMACRO, unusedArg1, path.c_str(), nullptr), Eq(EMacroResult::EncodingError));
+
+	// 読み込みに失敗したマクロオブジェクトは残らない
+	EXPECT_THAT(pcSMacroMgr->SetTempMacro(nullptr), IsNull());
+
+	// BOM付きUTF-8で書き込むと読み込める
+	{
+		std::ofstream fs(path, std::ios::binary);
+		fs << "\xEF\xBB\xBF" << macroBody;
+	}
+
+	EXPECT_THAT(pcSMacroMgr->Load(TEMP_KEYMACRO, unusedArg1, path.c_str(), nullptr), Eq(EMacroResult::Success));
+
+	pcSMacroMgr->Clear(TEMP_KEYMACRO);
+
+	std::error_code ec;
+	std::filesystem::remove(path, ec);
+
+	// 文字コード以外の理由(ファイルがない)で失敗したときは文字コードエラー扱いにならない
+	EXPECT_THAT(pcSMacroMgr->Load(TEMP_KEYMACRO, unusedArg1, path.c_str(), nullptr), Eq(EMacroResult::Failure));
 
 	CMacroFactory::getInstance()->Unregister(CWSHMacroManager::Creator);
 }


### PR DESCRIPTION
# PR対象

- アプリ(サクラエディタ本体)
- テストコード

## カテゴリ

- 不具合修正

## PR の背景

#2632

外部マクロファイルの読み込み中に文字コード変換が失敗した場合、エラーが利用者へ通知されず、マクロが何も実行されないように見えることがありました。

例えば、UTF-8 BOMなしのファイルはShift_JISとして読み込まれるため、内容によっては文字コード変換に失敗します。
この場合に、保存形式を確認できるエラーメッセージを表示するようにします。

## 仕様・動作説明

マクロファイルの読み込み中に文字コード変換が失敗した場合、次の内容を含むエラーメッセージを表示します。

- 文字コードの変換に失敗したこと
- BOM付きUTF-8またはShift_JIS等で保存されているか確認すること
- 対象となったマクロファイルのパス

次のマクロ実行経路で、文字コード変換エラーとその他の読み込みエラーを区別して表示します。

- 名前を指定してマクロ実行
- 登録済みマクロの実行
- キーボードマクロの実行

文字コードの判定仕様は変更していません。
UTF-8 BOMなしのマクロファイルをUTF-8として読み込む変更ではありません。

日本語、英語、中国語（簡体字）のメッセージリソースを追加しています。

## PR の影響範囲

マクロファイルの読み込み時に文字コード変換が失敗した場合のエラー処理とメッセージ表示に影響します。

文字コード以外の理由による読み込み失敗では、従来のエラーメッセージを表示します。
正常に読み込めるマクロの実行動作には変更ありません。

## テスト内容

x64 Debug構成でサクラエディタ本体と `tests1` をビルドし、テストが成功することを確認しました。

次の内容を確認する単体テストを追加しました。

- UTF-8 BOMなしの再現確認用JSマクロで、文字コード変換エラーが返されること
- 読み込みに失敗したマクロオブジェクトが残らないこと
- 失敗後にBOM付きUTF-8のマクロを正常に読み込めること
- 存在しないファイルの読み込み失敗が、文字コード変換エラーとして扱われないこと

また、デバッグビルドを使用して「名前を指定してマクロ実行」から再現確認用JSマクロを実行し、文字コードの保存形式と対象ファイルを示すエラーメッセージが表示されることを確認しました。
