### PR TITLE
SGrepOptionの廃止

### DIFF
--- a/sakura_core/agent/CGrepAgent.cpp
+++ b/sakura_core/agent/CGrepAgent.cpp
@@ -318,36 +318,6 @@ int GetHwndTitle(HWND& hWndTarget, CNativeW* pmemTitle, WCHAR* pszWindowName, WC
 }
 
 
-/*!	GrepInfo から出力オプションを取り出す
-
-	@param[in] gi Grep実行の入力一式
-	@return 出力・置換の挙動を決めるオプション
-	@note Grep置換では「一致しなかった行を出力」が成立しないため、行単位出力に落とす。
-*/
-SGrepOption SGrepOption::FromGrepInfo( const GrepInfo& gi )
-{
-	SGrepOption sGrepOption;
-	sGrepOption.bGrepSubFolder = gi.bGrepSubFolder;
-	sGrepOption.bGrepStdout = gi.bGrepStdout;
-	sGrepOption.bGrepHeader = gi.bGrepHeader;
-	sGrepOption.nGrepCharSet = gi.nGrepCharSet;
-	sGrepOption.nGrepOutputLineType = gi.nGrepOutputLineType;
-	sGrepOption.nGrepOutputStyle = gi.nGrepOutputStyle;
-	sGrepOption.bGrepOutputFileOnly = gi.bGrepOutputFileOnly;
-	sGrepOption.bGrepOutputBaseFolder = gi.bGrepOutputBaseFolder;
-	sGrepOption.bGrepSeparateFolder = gi.bGrepSeparateFolder;
-	sGrepOption.bGrepReplace = gi.bGrepReplace;
-	sGrepOption.bGrepPaste = gi.bGrepPaste;
-	sGrepOption.bGrepBackup = gi.bGrepBackup;
-	if( sGrepOption.bGrepReplace ){
-		// Grep否定行はGrep置換では無効
-		if( sGrepOption.nGrepOutputLineType == 2 ){
-			sGrepOption.nGrepOutputLineType = 1; // 行単位
-		}
-	}
-	return sGrepOption;
-}
-
 /*! Grep実行
 
   @param[in] pcViewDst Grep結果の出力先
@@ -381,7 +351,6 @@ DWORD CGrepAgent::DoGrep(
 	CNativeW	cmemMessage;
 	CNativeW	cUnicodeBuffer;
 	int			nWork;
-	SGrepOption	sGrepOption;
 
 	/*
 	|| バッファサイズの調整
@@ -501,7 +470,7 @@ DWORD CGrepAgent::DoGrep(
 	}
 	
 	// Grepオプションまとめ
-	sGrepOption = SGrepOption::FromGrepInfo( gi );
+	const GrepInfo sGrepOption = gi.Normalized();
 
 //2002.02.08 Grepアイコンも大きいアイコンと小さいアイコンを別々にする。
 	HICON	hIconBig, hIconSmall;
@@ -865,7 +834,7 @@ int CGrepAgent::DoGrepTree(
 	const WCHAR*			pszPath,			//!< [in] 検索対象パス
 	const WCHAR*			pszBasePath,		//!< [in] 検索対象パス(ベースフォルダー)
 	const SSearchOption&	sSearchOption,		//!< [in] 検索オプション
-	const SGrepOption&		sGrepOption,		//!< [in] Grepオプション
+	const GrepInfo&			sGrepOption,		//!< [in] Grep実行の入力一式(正規化済み)
 	const CSearchStringPattern& pattern,		//!< [in] 検索パターン
 	CBregexp*				pRegexp,			//!< [in] 正規表現コンパイルデータ。既にコンパイルされている必要がある
 	int						nNest,				//!< [in] ネストレベル
@@ -1135,7 +1104,7 @@ void CGrepAgent::SetGrepResult(
 	const wchar_t*	pMatchData,		/*!< [in] マッチした文字列 */
 	int			nMatchLen,			/*!< [in] マッチした文字列の長さ */
 	/* オプション */
-	const SGrepOption&	sGrepOption
+	const GrepInfo&		sGrepOption
 )
 {
 	CNativeW cmemBuf(L"");
@@ -1199,7 +1168,7 @@ void CGrepAgent::SetGrepResult(
 
 static void OutputPathInfo(
 	CNativeW&		cmemMessage,
-	SGrepOption		sGrepOption,
+	const GrepInfo&	sGrepOption,
 	const WCHAR*	pszFullPath,
 	const WCHAR*	pszBaseFolder,
 	const WCHAR*	pszFolder,
@@ -1277,7 +1246,7 @@ int CGrepAgent::DoGrepFile(
 	const wchar_t*			pszKey,				//!< [in] 検索パターン
 	const WCHAR*			pszFile,			//!< [in] 処理対象ファイル名(表示用)
 	const SSearchOption&	sSearchOption,		//!< [in] 検索オプション
-	const SGrepOption&		sGrepOption,		//!< [in] Grepオプション
+	const GrepInfo&			sGrepOption,		//!< [in] Grep実行の入力一式(正規化済み)
 	const CSearchStringPattern& pattern,		//!< [in] 検索パターン
 	CBregexp*				pRegexp,			//!< [in] 正規表現コンパイルデータ。既にコンパイルされている必要がある
 	int*					pnHitCount,			//!< [i/o] ヒット数の合計．元々の値に見つかった数を加算して返す．
@@ -1823,7 +1792,7 @@ int CGrepAgent::DoGrepReplaceFile(
 	const CNativeW&			cmGrepReplace,
 	const WCHAR*			pszFile,
 	const SSearchOption&	sSearchOption,
-	const SGrepOption&		sGrepOption,
+	const GrepInfo&			sGrepOption,
 	const CSearchStringPattern& pattern,
 	CBregexp*				pRegexp,		//	Jun. 27, 2001 genta	正規表現ライブラリの差し替え
 	int*					pnHitCount,

--- a/sakura_core/agent/CGrepAgent.h
+++ b/sakura_core/agent/CGrepAgent.h
@@ -18,39 +18,6 @@ class CGrepEnumFiles;
 class CGrepEnumFolders;
 struct GrepInfo;
 
-struct SGrepOption{
-	bool		bGrepReplace;			//!< Grep置換
-	bool		bGrepSubFolder;			//!< サブフォルダーからも検索する
-	bool		bGrepStdout;			//!< 標準出力モード
-	bool		bGrepHeader;			//!< ヘッダー・フッター表示
-	ECodeType	nGrepCharSet;			//!< 文字コードセット選択
-	int			nGrepOutputLineType;	//!< 0:ヒット部分を出力, 1: ヒット行を出力, 2: 否ヒット行を出力
-	int			nGrepOutputStyle;		//!< 出力形式 1: Normal, 2: WZ風(ファイル単位) 3: 結果のみ
-	bool		bGrepOutputFileOnly;	//!< ファイル毎最初のみ検索
-	bool		bGrepOutputBaseFolder;	//!< ベースフォルダー表示
-	bool		bGrepSeparateFolder;	//!< フォルダー毎に表示
-	bool		bGrepPaste;				//!< Grep置換：クリップボードから貼り付ける
-	bool		bGrepBackup;			//!< Grep置換：バックアップ
-
-	SGrepOption() :
-		 bGrepReplace(false)
-		,bGrepSubFolder(true)
-		,bGrepStdout(false)
-		,bGrepHeader(true)
-		,nGrepCharSet(CODE_AUTODETECT)
-		,nGrepOutputLineType(1)
-		,nGrepOutputStyle(1)
-		,bGrepOutputFileOnly(false)
-		,bGrepOutputBaseFolder(false)
-		,bGrepSeparateFolder(false)
-		,bGrepPaste(false)
-		,bGrepBackup(false)
-	{}
-
-	//! GrepInfo から出力オプションを取り出す(Grep置換では否ヒット行の出力が無効になる)
-	static SGrepOption FromGrepInfo( const GrepInfo& gi );
-};
-
 //	Jun. 26, 2001 genta	正規表現ライブラリの差し替え
 //	Mar. 28, 2004 genta DoGrepFileから不要な引数を削除
 class CGrepAgent : public CDocListenerEx{
@@ -84,7 +51,7 @@ private:
 		const WCHAR*			pszPath,			//!< [in] 検索対象パス
 		const WCHAR*			pszBasePath,		//!< [in] 検索対象パス(ベース)
 		const SSearchOption&	sSearchOption,		//!< [in] 検索オプション
-		const SGrepOption&		sGrepOption,		//!< [in] Grepオプション
+		const GrepInfo&			sGrepOption,		//!< [in] Grep実行の入力一式(正規化済み)
 		const CSearchStringPattern& pattern,		//!< [in] 検索パターン
 		CBregexp*				pRegexp,			//!< [in] 正規表現コンパイルデータ。既にコンパイルされている必要がある
 		int						nNest,				//!< [in] ネストレベル
@@ -102,7 +69,7 @@ private:
 		const wchar_t*			pszKey,
 		const WCHAR*			pszFile,
 		const SSearchOption&	sSearchOption,
-		const SGrepOption&		sGrepOption,
+		const GrepInfo&			sGrepOption,
 		const CSearchStringPattern& pattern,
 		CBregexp*				pRegexp,		//	Jun. 27, 2001 genta	正規表現ライブラリの差し替え
 		int*					pnHitCount,
@@ -123,7 +90,7 @@ private:
 		const CNativeW&			cmGrepReplace,
 		const WCHAR*			pszFile,
 		const SSearchOption&	sSearchOption,
-		const SGrepOption&		sGrepOption,
+		const GrepInfo&			sGrepOption,
 		const CSearchStringPattern& pattern,
 		CBregexp*				pRegexp,
 		int*					pnHitCount,
@@ -154,7 +121,7 @@ private:
 		const wchar_t*	pMatchData,		//	マッチした文字列
 		int				nMatchLen,		//	マッチした文字列の長さ
 		// オプション
-		const SGrepOption&	sGrepOption
+		const GrepInfo&		sGrepOption
 	);
 
 	DWORD m_dwTickAddTail = 0;	// AddTail() を呼び出した時間

--- a/sakura_core/basis/GrepInfo.cpp
+++ b/sakura_core/basis/GrepInfo.cpp
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -13,4 +13,19 @@
  */
 GrepInfo::GrepInfo() noexcept
 {
+}
+
+/*!	正規化した GrepInfo を返す
+
+	@return 出力・置換の挙動が矛盾しないよう補正した複製
+	@note Grep置換では「一致しなかった行を出力」が成立しないため、行単位出力に落とす。
+*/
+GrepInfo GrepInfo::Normalized() const
+{
+	GrepInfo gi = *this;
+	// Grep否定行はGrep置換では無効
+	if( gi.bGrepReplace && gi.nGrepOutputLineType == 2 ){
+		gi.nGrepOutputLineType = 1; // 行単位
+	}
+	return gi;
 }

--- a/sakura_core/basis/GrepInfo.h
+++ b/sakura_core/basis/GrepInfo.h
@@ -1,6 +1,6 @@
 ﻿/*! @file */
 /*
-	Copyright (C) 2018-2022, Sakura Editor Organization
+	Copyright (C) 2018-2026, Sakura Editor Organization
 
 	SPDX-License-Identifier: Zlib
 */
@@ -42,5 +42,8 @@ struct GrepInfo {
 
 	// コンストラクタ
 	GrepInfo() noexcept;
+
+	//! 出力・置換の挙動が矛盾しないよう補正した複製を返す
+	GrepInfo Normalized() const;
 };
 #endif /* SAKURA_GREPINFO_9A59ABAF_04F9_4D29_B216_0B0784DD2290_H_ */

--- a/src/test/cpp/tests1/test-grepinfo.cpp
+++ b/src/test/cpp/tests1/test-grepinfo.cpp
@@ -9,7 +9,6 @@
 #include <Windows.h>
 
 #include "basis/GrepInfo.h"
-#include "agent/CGrepAgent.h"
 #include "dlg/CDlgGrepReplace.h"
 #include "env/ShareDataTestSuite.hpp"
 
@@ -184,10 +183,10 @@ TEST(GrepInfo, operatorEqualAndNotEqual)
 }
 
 /*!
- * @brief SGrepOption::FromGrepInfo() のテスト
- *  GrepInfo の各メンバが SGrepOption の対応するメンバへ移されること
+ * @brief GrepInfo::Normalized() のテスト
+ *  補正対象以外のメンバがそのまま引き継がれること
  */
-TEST(SGrepOption, FromGrepInfo_CopiesMembers)
+TEST(GrepInfo, Normalized_KeepsOtherMembers)
 {
 	GrepInfo gi;
 	gi.bGrepSubFolder = true;
@@ -203,52 +202,68 @@ TEST(SGrepOption, FromGrepInfo_CopiesMembers)
 	gi.bGrepPaste = true;
 	gi.bGrepBackup = true;
 
-	const SGrepOption option = SGrepOption::FromGrepInfo(gi);
+	const GrepInfo normalized = gi.Normalized();
 
-	EXPECT_TRUE(option.bGrepSubFolder);
-	EXPECT_TRUE(option.bGrepStdout);
-	EXPECT_FALSE(option.bGrepHeader);
-	EXPECT_EQ(CODE_EUC, option.nGrepCharSet);
-	EXPECT_EQ(1, option.nGrepOutputLineType);
-	EXPECT_EQ(3, option.nGrepOutputStyle);
-	EXPECT_TRUE(option.bGrepOutputFileOnly);
-	EXPECT_TRUE(option.bGrepOutputBaseFolder);
-	EXPECT_TRUE(option.bGrepSeparateFolder);
-	EXPECT_FALSE(option.bGrepReplace);
-	EXPECT_TRUE(option.bGrepPaste);
-	EXPECT_TRUE(option.bGrepBackup);
+	EXPECT_TRUE(normalized.bGrepSubFolder);
+	EXPECT_TRUE(normalized.bGrepStdout);
+	EXPECT_FALSE(normalized.bGrepHeader);
+	EXPECT_EQ(CODE_EUC, normalized.nGrepCharSet);
+	EXPECT_EQ(1, normalized.nGrepOutputLineType);
+	EXPECT_EQ(3, normalized.nGrepOutputStyle);
+	EXPECT_TRUE(normalized.bGrepOutputFileOnly);
+	EXPECT_TRUE(normalized.bGrepOutputBaseFolder);
+	EXPECT_TRUE(normalized.bGrepSeparateFolder);
+	EXPECT_FALSE(normalized.bGrepReplace);
+	EXPECT_TRUE(normalized.bGrepPaste);
+	EXPECT_TRUE(normalized.bGrepBackup);
 }
 
 /*!
- * @brief SGrepOption::FromGrepInfo() のテスト
+ * @brief GrepInfo::Normalized() のテスト
  *  Grep置換では「一致しなかった行を出力」が行単位出力に落ちること
  */
-TEST(SGrepOption, FromGrepInfo_ReplaceDisablesNoHitLine)
+TEST(GrepInfo, Normalized_ReplaceDisablesNoHitLine)
 {
 	GrepInfo gi;
 	gi.bGrepReplace = true;
 	gi.nGrepOutputLineType = 2;	// 否ヒット行を出力
 
-	const SGrepOption option = SGrepOption::FromGrepInfo(gi);
+	const GrepInfo normalized = gi.Normalized();
 
-	EXPECT_TRUE(option.bGrepReplace);
-	EXPECT_EQ(1, option.nGrepOutputLineType);	// 行単位に落ちる
+	EXPECT_TRUE(normalized.bGrepReplace);
+	EXPECT_EQ(1, normalized.nGrepOutputLineType);	// 行単位に落ちる
 }
 
 /*!
- * @brief SGrepOption::FromGrepInfo() のテスト
+ * @brief GrepInfo::Normalized() のテスト
  *  Grep置換でなければ「一致しなかった行を出力」がそのまま残ること
  */
-TEST(SGrepOption, FromGrepInfo_KeepsNoHitLineWhenNotReplace)
+TEST(GrepInfo, Normalized_KeepsNoHitLineWhenNotReplace)
 {
 	GrepInfo gi;
 	gi.bGrepReplace = false;
 	gi.nGrepOutputLineType = 2;
 
-	const SGrepOption option = SGrepOption::FromGrepInfo(gi);
+	const GrepInfo normalized = gi.Normalized();
 
-	EXPECT_FALSE(option.bGrepReplace);
-	EXPECT_EQ(2, option.nGrepOutputLineType);
+	EXPECT_FALSE(normalized.bGrepReplace);
+	EXPECT_EQ(2, normalized.nGrepOutputLineType);
+}
+
+/*!
+ * @brief GrepInfo::Normalized() のテスト
+ *  元のオブジェクトが変更されないこと
+ */
+TEST(GrepInfo, Normalized_DoesNotModifySelf)
+{
+	GrepInfo gi;
+	gi.bGrepReplace = true;
+	gi.nGrepOutputLineType = 2;
+
+	const GrepInfo normalized = gi.Normalized();
+
+	EXPECT_EQ(2, gi.nGrepOutputLineType);
+	EXPECT_EQ(1, normalized.nGrepOutputLineType);
 }
 
 /*!


### PR DESCRIPTION
## 概要

`SGrepOption` を廃止し、`CGrepAgent` の内部を `GrepInfo` で通すようにしました。
振る舞いは変更していません。

## 変更内容

| ファイル | 内容 |
|---|---|
| `basis/GrepInfo.h` / `.cpp` | `Normalized()` を追加（`SGrepOption::FromGrepInfo()` の補正を移動） |
| `agent/CGrepAgent.h` / `.cpp` | `SGrepOption` を削除し、引数型を `const GrepInfo&` に変更 |
| `test-grepinfo.cpp` | `FromGrepInfo` の 3 テストを `Normalized()` 向けに書き換え、4 件に |

## 型を変えた以外の変更（1 箇所）

`OutputPathInfo()` の第 2 引数を値渡しから `const GrepInfo&` に変更しました。
`GrepInfo` は `CNativeW` を 4 つ持つため、値渡しのままだとヒット 1 件ごとに
4 回のヒープコピーが発生します。

## 変数名 `sGrepOption` を据え置いた理由

型は `GrepInfo` になりましたが名前は変えていません。この識別子は 116 行に出現し、
うち 85 行は単体テストから到達できない関数の内部です。リネームするとこれらが
New Code として計上され、カバレッジ条件を満たせなくなります。`DoGrepFile()` の
構造を変更する PR に合わせて改名する予定です。
